### PR TITLE
sqlparse: Added keywords for PostgreSQL

### DIFF
--- a/SQLToolsAPI/lib/sqlparse/keywords.py
+++ b/SQLToolsAPI/lib/sqlparse/keywords.py
@@ -696,6 +696,21 @@ KEYWORDS_COMMON = {
     'MIN': tokens.Keyword,
     'MAX': tokens.Keyword,
     'DISTINCT': tokens.Keyword,
+
+     # PostgreSQL Syntax
+    'PARTITION':    tokens.Keyword,
+    'OVER':         tokens.Keyword,
+    'PERFORM':      tokens.Keyword,
+    'NOTICE':       tokens.Keyword,
+    'PLPGSQL':      tokens.Keyword,
+    'INHERIT':      tokens.Keyword,
+    'INDEXES':      tokens.Keyword,
+
+    'FOR':          tokens.Keyword,
+    'IN':           tokens.Keyword,
+    'LOOP':         tokens.Keyword,
+
+
 }
 
 KEYWORDS_ORACLE = {


### PR DESCRIPTION
Hey, I am working on a Postgres-based Data Warehousing project. The formatting tool has been a life-saver in the recent days. However, I had to add a couple of keywords to the sqlparse library. Check it out. 

Best,
Demetrio