### PR TITLE
Add options: safe_limit, show_query and expand_to_paragraph

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -5,6 +5,7 @@ import os
 
 import sublime
 from sublime_plugin import WindowCommand, EventListener, TextCommand
+from Default.paragraph import expand_to_paragraph
 
 from .SQLToolsAPI import Utils
 from .SQLToolsAPI.Log import Log, Logger
@@ -132,7 +133,10 @@ def getSelection():
     if View().sel():
         for region in View().sel():
             if region.empty():
-                text.append(View().substr(View().line(region)))
+                if not settings.get('expand_to_paragraph', False):
+                    text.append(View().substr(View().line(region)))
+                else:
+                    text.append(View().substr(expand_to_paragraph(View(), region.b)))
             else:
                 text.append(View().substr(region))
     return text

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -5,6 +5,7 @@
     "show_result_on_window" : false,
     "clear_output"          : false,
     "safe_limit"            : false,
+    "show_query"            : false,
     /**
      * The list of syntax selector for which the plugin autocompletion will be active.
      * An empty list means autocompletion always active.

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -6,6 +6,7 @@
     "clear_output"          : false,
     "safe_limit"            : false,
     "show_query"            : false,
+    "expand_to_paragraph"   : false,
     /**
      * The list of syntax selector for which the plugin autocompletion will be active.
      * An empty list means autocompletion always active.

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -4,7 +4,7 @@
     "history_size"          : 100,
     "show_result_on_window" : false,
     "clear_output"          : false,
-    "safe_limit"            : 1000,
+    "safe_limit"            : false,
     /**
      * The list of syntax selector for which the plugin autocompletion will be active.
      * An empty list means autocompletion always active.

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -4,6 +4,7 @@
     "history_size"          : 100,
     "show_result_on_window" : false,
     "clear_output"          : false,
+    "safe_limit"            : 1000,
     /**
      * The list of syntax selector for which the plugin autocompletion will be active.
      * An empty list means autocompletion always active.

--- a/SQLToolsAPI/Command.py
+++ b/SQLToolsAPI/Command.py
@@ -10,13 +10,16 @@ from .Log import Log
 class Command:
     timeout = 5000
 
-    def __init__(self, args, callback, query=None, encoding='utf-8', options={}):
+    def __init__(self, args, callback, query=None, encoding='utf-8', options=None):
         self.query = query
         self.process = None
         self.args = args
         self.encoding = encoding
         self.callback = callback
         self.options = options
+        # Don't allow empty dicts or lists as defaults in method signature, cfr http://nedbatchelder.com/blog/200806/pylint.html
+        if self.options is None:
+            self.options = {}
         Thread.__init__(self)
 
     def run(self):
@@ -64,14 +67,17 @@ class Command:
         self.callback(resultString)
 
     @staticmethod
-    def createAndRun(args, query, callback, options={}):
+    def createAndRun(args, query, callback, options=None):
+        # Don't allow empty dicts or lists as defaults in method signature, cfr http://nedbatchelder.com/blog/200806/pylint.html
+        if options is None:
+            options = {}
         command = Command(args, callback, query, options=options)
         command.run()
 
 
 class ThreadCommand(Command, Thread):
     def __init__(self, args, callback, query=None, encoding='utf-8',
-                 options={}, timeout=Command.timeout):
+                 options=None, timeout=Command.timeout):
         self.query = query
         self.process = None
         self.args = args
@@ -79,6 +85,9 @@ class ThreadCommand(Command, Thread):
         self.callback = callback
         self.options = options
         self.timeout = timeout
+        # Don't allow empty dicts or lists as defaults in method signature, cfr http://nedbatchelder.com/blog/200806/pylint.html
+        if self.options is None:
+            self.options = {}
         Thread.__init__(self)
 
     def stop(self):
@@ -94,7 +103,10 @@ class ThreadCommand(Command, Thread):
             pass
 
     @staticmethod
-    def createAndRun(args, query, callback, options={}):
+    def createAndRun(args, query, callback, options=None):
+        # Don't allow empty dicts or lists as defaults in method signature, cfr http://nedbatchelder.com/blog/200806/pylint.html
+        if options is None:
+            options = {}
         command = ThreadCommand(args, callback, query, options=options)
         command.start()
         killTimeout = Timer(command.timeout, command.stop)

--- a/SQLToolsAPI/Command.py
+++ b/SQLToolsAPI/Command.py
@@ -58,8 +58,8 @@ class Command:
                 str(queryTimerEnd-queryTimerStart)
                 )
             resultLine = "-"*(len(resultInfo)-3)
-            resultInfo = "{0}\n{1}".format(resultInfo,resultLine)
-            resultString = "{0}\n{1}\n{2}\n*/\n{3}".format(resultInfo,self.query,resultLine,resultString)
+            resultString = "{0}\n{1}\n{2}\n{3}\n*/\n{4}".format(resultInfo,
+                resultLine,self.query,resultLine,resultString)
 
         self.callback(resultString)
 

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -113,6 +113,9 @@ class Connection:
             if query.lower().startswith('select'):
                 if not " limit " in query.lower()[-15:]:
                     if self.safe_limit:
+                        if ";" in query.lower()[-5:]:
+                            seperatorIndex = query.rfind(';')
+                            query = query[:seperatorIndex] + query[seperatorIndex+1:]
                         query += " LIMIT {0}".format(self.safe_limit)
             queryToRun += query + "\n"
 

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -21,6 +21,7 @@ class Connection:
     password = None
     service = None
     safe_limit = None
+    show_query = None
 
     def __init__(self, name, options, settings={}, commandClass='ThreadCommand'):
         self.Command = getattr(C, commandClass)
@@ -48,6 +49,7 @@ class Connection:
         self.password  = options.get('password', None)
         self.service   = options.get('service', None)
         self.safe_limit = settings.get('safe_limit', None)
+        self.show_query = settings.get('show_query', None)
 
     def __str__(self):
         return self.name
@@ -111,7 +113,7 @@ class Connection:
 
         for query in queries:
             if query.lower().startswith('select'):
-                if not " limit " in query.lower()[-15:]:
+                if " limit " not in query.lower()[-15:]:
                     if self.safe_limit:
                         if ";" in query.lower()[-5:]:
                             seperatorIndex = query.rfind(';')
@@ -126,7 +128,7 @@ class Connection:
         if Connection.history:
             Connection.history.add(queryToRun)
 
-        self.Command.createAndRun(self.builArgs(), queryToRun, callback)
+        self.Command.createAndRun(self.builArgs(), queryToRun, callback, options={'show_query':self.show_query})
 
     def builArgs(self, queryName=None):
         cliOptions = self.getOptionsForSgdbCli()

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -20,6 +20,7 @@ class Connection:
     encoding = None
     password = None
     service = None
+    safe_limit = None
 
     def __init__(self, name, options, settings={}, commandClass='ThreadCommand'):
         self.Command = getattr(C, commandClass)
@@ -46,6 +47,7 @@ class Connection:
         self.encoding  = options.get('encoding', None)
         self.password  = options.get('password', None)
         self.service   = options.get('service', None)
+        self.safe_limit = settings.get('safe_limit', None)
 
     def __str__(self):
         return self.name
@@ -108,6 +110,10 @@ class Connection:
             queries = [queries]
 
         for query in queries:
+            if query.lower().startswith('select'):
+                if not " limit " in query.lower()[-15:]:
+                    if self.safe_limit:
+                        query += " LIMIT {0}".format(self.safe_limit)
             queryToRun += query + "\n"
 
         queryToRun = queryToRun.rstrip('\n')

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -1,5 +1,6 @@
 import shutil
 import shlex
+import sqlparse
 
 from .Log import Log
 from . import Utils as U
@@ -111,24 +112,31 @@ class Connection:
         if isinstance(queries, str):
             queries = [queries]
 
-        for query in queries:
-            if query.lower().startswith('select'):
-                if " limit " not in query.lower()[-15:]:
-                    if self.safe_limit:
-                        if ";" in query.lower()[-5:]:
-                            seperatorIndex = query.rfind(';')
-                            query = query[:seperatorIndex] + query[seperatorIndex+1:]
-                        query += " LIMIT {0}".format(self.safe_limit)
-            queryToRun += query + "\n"
-
-        queryToRun = queryToRun.rstrip('\n')
+        for rawQuery in queries:
+            for query in sqlparse.split(rawQuery):
+                if self.safe_limit:
+                    parsedTokens = sqlparse.parse(query.strip().replace("'", "\""))
+                    if ((parsedTokens[0].ttype in sqlparse.tokens.Keyword and
+                            parsedTokens[0].value == 'select') or
+                            query.strip().lower().startswith('select')):
+                        applySafeLimit = True
+                        for parse in parsedTokens:
+                            for token in parse.tokens:
+                                if token.ttype in sqlparse.tokens.Keyword and token.value == 'limit':
+                                    applySafeLimit = False
+                        if applySafeLimit:
+                            print ('NO limit found in ' + query)
+                            if (query.strip()[-1:] == ';'):
+                                query = query.strip()[:-1]
+                            query += " LIMIT {0};".format(self.safe_limit)
+                queryToRun += query + "\n"
 
         Log("Query: " + queryToRun)
 
         if Connection.history:
             Connection.history.add(queryToRun)
 
-        self.Command.createAndRun(self.builArgs(), queryToRun, callback, options={'show_query':self.show_query})
+        self.Command.createAndRun(self.builArgs(), queryToRun, callback, options={'show_query': self.show_query})
 
     def builArgs(self, queryName=None):
         cliOptions = self.getOptionsForSgdbCli()

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -125,7 +125,6 @@ class Connection:
                                 if token.ttype in sqlparse.tokens.Keyword and token.value == 'limit':
                                     applySafeLimit = False
                         if applySafeLimit:
-                            print ('NO limit found in ' + query)
                             if (query.strip()[-1:] == ';'):
                                 query = query.strip()[:-1]
                             query += " LIMIT {0};".format(self.safe_limit)

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -116,9 +116,8 @@ class Connection:
             for query in sqlparse.split(rawQuery):
                 if self.safe_limit:
                     parsedTokens = sqlparse.parse(query.strip().replace("'", "\""))
-                    if ((parsedTokens[0].ttype in sqlparse.tokens.Keyword and
-                            parsedTokens[0].value == 'select') or
-                            query.strip().lower().startswith('select')):
+                    if ((parsedTokens[0][0].ttype in sqlparse.tokens.Keyword and
+                            parsedTokens[0][0].value == 'select')):
                         applySafeLimit = True
                         for parse in parsedTokens:
                             for token in parse.tokens:


### PR DESCRIPTION
Define a minimum limit to avoid accidental big and slow queries.
If query is a SELECT and doesn't contain a LIMIT and safe_limit is set, then add a LIMIT
option= safe_limit

&

Show above the results the executed query, including a timestamp and duration
option= show_query