### PR TITLE
Make `Connection.py` to run commands in `before` items in the main setting file.

### DIFF
--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -92,16 +92,19 @@ class Connection:
 
     def getTableRecords(self, tableName, callback):
         query = self.getOptionsForSgdbCli()['queries']['show records']['query'].format(tableName, self.rowsLimit)
-        self.Command.createAndRun(self.builArgs('show records'), query, callback)
+        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
+        self.Command.createAndRun(self.builArgs('show records'), queryToRun, callback)
 
     def getTableDescription(self, tableName, callback):
         query = self.getOptionsForSgdbCli()['queries']['desc table']['query'] % tableName
-        self.Command.createAndRun(self.builArgs('desc table'), query, callback)
+        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
+        self.Command.createAndRun(self.builArgs('desc table'), queryToRun, callback)
 
     def getFunctionDescription(self, functionName, callback):
         query = self.getOptionsForSgdbCli()['queries']['desc function'][
             'query'] % functionName
-        self.Command.createAndRun(self.builArgs('desc function'), query, callback)
+        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
+        self.Command.createAndRun(self.builArgs('desc function'), queryToRun, callback)
 
     def execute(self, queries, callback):
         queryToRun = ''


### PR DESCRIPTION
I found that the code lines described in `before` items in the `SQLTools.sublime-settings` are not run when we execute the  package commands other than the `ST: Execute` package command.
I think they should be run, because there are some problems such as we get wrapped lines in the result of `ST: Show Table Records` command on Oracle DB (though the results of `ST: Execute` are not wrapped), unless we execute them.
This PR fixes the problem. I wonder if there are better ways to fix, but it works.
Sorry that I've tested on only Oracle DB, but I think it doesn't cause problems on other DBs.

Thanks,