### PR TITLE
Added explain plan command

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
     { "keys": ["ctrl+e", "ctrl+d"], "command": "st_desc_table" },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
     { "keys": ["ctrl+e", "ctrl+d"], "command": "st_desc_table" },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
     { "keys": ["ctrl+e", "ctrl+d"], "command": "st_desc_table" },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,6 +8,10 @@
     "command": "st_execute"
   },
   {
+    "caption": "ST: Explain Plan",
+    "command": "st_explain_plan"
+  },
+  {
     "caption": "ST: History",
     "command": "st_history"
   },

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -348,6 +348,16 @@ class StDescFunction(WindowCommand):
         ST.selectFunction(cb)
 
 
+class StExplainPlan(WindowCommand):
+    @staticmethod
+    def run():
+        if not ST.conn:
+            ST.selectConnection(tablesCallback=lambda: Window().run_command('st_explain_plan'))
+            return
+
+        ST.conn.explainPlan(getSelection(), output)
+
+
 class StExecute(WindowCommand):
     @staticmethod
     def run():

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -121,7 +121,7 @@
                     "format" : "|%s|"
                 },
                 "explain plan": {
-                    "query": "explain plan for {0}; select plan_table_output from table(dbms_xplain.display());",
+                    "query": "explain plan for {0};\nselect plan_table_output from table(dbms_xplan.display());",
                     "options": ["-S"],
                     "format" : "|%s|"
                 }

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -77,6 +77,11 @@
                     "query": "\\sf %s",
                     "options": [],
                     "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "explain {0};",
+                    "options": [],
+                    "format" : "|%s|"
                 }
             }
         },
@@ -151,6 +156,11 @@
                     "query": "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = DATABASE();",
                     "options": ["-f", "--table"],
                     "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "explain {0};",
+                    "options": ["-f", "--table"],
+                    "format" : "|%s|"
                 }
             }
         },
@@ -171,6 +181,11 @@
                 },
                 "show records": {
                     "query": "select * from {0} limit {1}",
+                    "options": [],
+                    "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "explain {0};",
                     "options": [],
                     "format" : "|%s|"
                 }
@@ -218,6 +233,11 @@
                 },
                 "show records": {
                     "query": "select * from \"{0}\" limit {1};",
+                    "options": ["-column"],
+                    "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "EXPLAIN QUERY PLAN {0};",
                     "options": ["-column"],
                     "format" : "|%s|"
                 }

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -119,6 +119,11 @@
                     "query": "select * from {0} WHERE ROWNUM <= {1};",
                     "options": ["-S"],
                     "format" : "|%s|"
+                },
+                "explain plan": {
+                    "query": "explain plan for {0}; select plan_table_output from table(dbms_xplain.display());",
+                    "options": ["-S"],
+                    "format" : "|%s|"
                 }
             }
         },

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -107,11 +107,15 @@ class Connection:
         self.Command.createAndRun(self.builArgs('desc function'), queryToRun, callback)
 
     def explainPlan(self, queries, callback):
-        queryFormat = self.getOptionsForSgdbCli()['queries']['explain plan']['query']
+        try:
+            queryFormat = self.getOptionsForSgdbCli()['queries']['explain plan']['query']
+        except KeyError:
+            return # do nothing, if DBMS has no support for explain plan
+
         stripped_queries = [
             queryFormat.format(query.strip().strip(";"))
             for rawQuery in queries
-            for query in sqlparse.split(rawQuery)
+            for query in filter(None, sqlparse.split(rawQuery))
         ]
         queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + stripped_queries)
         self.Command.createAndRun(self.builArgs('explain plan'), queryToRun, callback)

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -106,6 +106,11 @@ class Connection:
         queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
         self.Command.createAndRun(self.builArgs('desc function'), queryToRun, callback)
 
+    def explainPlan(self, query, callback):
+        query = self.getOptionsForSgdbCli()['queries']['explain plan']['query'].format(query)
+        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
+        self.Command.createAndRun(self.builArgs('explain plan'), queryToRun, callback)
+
     def execute(self, queries, callback):
         queryToRun = ''
 

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -106,9 +106,14 @@ class Connection:
         queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
         self.Command.createAndRun(self.builArgs('desc function'), queryToRun, callback)
 
-    def explainPlan(self, query, callback):
-        query = self.getOptionsForSgdbCli()['queries']['explain plan']['query'].format(query)
-        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
+    def explainPlan(self, queries, callback):
+        queryFormat = self.getOptionsForSgdbCli()['queries']['explain plan']['query']
+        stripped_queries = [
+            queryFormat.format(query.strip().strip(";"))
+            for rawQuery in queries
+            for query in sqlparse.split(rawQuery)
+        ]
+        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + stripped_queries)
         self.Command.createAndRun(self.builArgs('explain plan'), queryToRun, callback)
 
     def execute(self, queries, callback):


### PR DESCRIPTION
This commit is for #64 .
Added `ST: Explain Plan` command to get execution plan for the query.

This is still a draft because I worked only on Oracle.
This feature requires DB specific codes therefore testing with each DB is necessary, but currently I don't have environments with DB other than Oracle. I need to set up DBs to complete this PR but it should take some more time, so I'll be very glad if somebody help making it handling other DBs.

Thanks.