### PR TITLE
show autocomplete for popular SQL syntax highlights

### DIFF
--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -11,7 +11,7 @@
      * The list of syntax selector for which the plugin autocompletion will be active.
      * An empty list means autocompletion always active.
      */
-    "selectors": ["source.sql"],
+    "selectors": ["source.sql", "source.pgsql", "source.plpgsql.postgres", "source.plsql.oracle", "source.tsql"],
     "unescape_quotes" : [
         "php"
     ],


### PR DESCRIPTION
Add additional SQL syntax highlights to selectors list
in default settings. This will make autocomplete to work with
these addtional syntax highlights out of the box:
  * PostgreSQL Syntax Highlighting
    https://github.com/tkopets/sublime-postgresql-syntax
  * Postgres PL pgSQL
    https://github.com/mulander/postgres.tmbundle
  * Oracle PL SQL
    https://github.com/mulander/oracle.tmbundle
  * TSQLEasy
    https://github.com/tosher/TSQLEasy

fixes #61 