### PR TITLE
Take into account configurable "thread_timeout" for long running commands

### DIFF
--- a/SQLToolsAPI/Command.py
+++ b/SQLToolsAPI/Command.py
@@ -95,7 +95,9 @@ class ThreadCommand(Command, Thread):
             return
 
         try:
-            os.kill(self.process.pid, signal.SIGKILL)
+            # Windows does not provide SIGKILL, go with SIGTERM
+            sig = getattr(signal, 'SIGKILL', signal.SIGTERM)
+            os.kill(self.process.pid, sig)
             self.process = None
 
             Log.debug("Your command is taking too long to run. Process killed")

--- a/SQLToolsAPI/Command.py
+++ b/SQLToolsAPI/Command.py
@@ -103,11 +103,11 @@ class ThreadCommand(Command, Thread):
             pass
 
     @staticmethod
-    def createAndRun(args, query, callback, options=None):
+    def createAndRun(args, query, callback, options=None, timeout=Command.timeout):
         # Don't allow empty dicts or lists as defaults in method signature, cfr http://nedbatchelder.com/blog/200806/pylint.html
         if options is None:
             options = {}
-        command = ThreadCommand(args, callback, query, options=options)
+        command = ThreadCommand(args, callback, query, options=options, timeout=timeout)
         command.start()
         killTimeout = Timer(command.timeout, command.stop)
         killTimeout.start()

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -8,6 +8,7 @@ from . import Command as C
 
 
 class Connection:
+    timeout = None
     history = None
     settings = None
     rowsLimit = None
@@ -93,7 +94,7 @@ class Connection:
     def getTableRecords(self, tableName, callback):
         query = self.getOptionsForSgdbCli()['queries']['show records']['query'].format(tableName, self.rowsLimit)
         queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
-        self.Command.createAndRun(self.builArgs('show records'), queryToRun, callback)
+        self.Command.createAndRun(self.builArgs('show records'), queryToRun, callback, timeout=self.timeout)
 
     def getTableDescription(self, tableName, callback):
         query = self.getOptionsForSgdbCli()['queries']['desc table']['query'] % tableName
@@ -118,7 +119,7 @@ class Connection:
             for query in filter(None, sqlparse.split(rawQuery))
         ]
         queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + stripped_queries)
-        self.Command.createAndRun(self.builArgs('explain plan'), queryToRun, callback)
+        self.Command.createAndRun(self.builArgs('explain plan'), queryToRun, callback, timeout=self.timeout)
 
     def execute(self, queries, callback):
         queryToRun = ''
@@ -151,7 +152,7 @@ class Connection:
         if Connection.history:
             Connection.history.add(queryToRun)
 
-        self.Command.createAndRun(self.builArgs(), queryToRun, callback, options={'show_query': self.show_query})
+        self.Command.createAndRun(self.builArgs(), queryToRun, callback, options={'show_query': self.show_query}, timeout=self.timeout)
 
     def builArgs(self, queryName=None):
         cliOptions = self.getOptionsForSgdbCli()
@@ -178,7 +179,7 @@ class Connection:
     @staticmethod
     def setTimeout(timeout):
         Connection.timeout = timeout
-        Log('Connection timeout setted to {0} seconds'.format(timeout))
+        Log('Connection timeout set to {0} seconds'.format(timeout))
 
     @staticmethod
     def setHistoryManager(manager):


### PR DESCRIPTION
The configurable setting of "thread_timeout" is now taken into account when executing commands that can potentially take a long time to complete.
Configurable "thread_timeout" setting is used for these commands:
  * Execute query
  * Explain query
  * Show table records

Also, fixes the code for terminating the process on Windows platforms.

Fixes #79 

@mtxr 
I'm don't commit these directly to master as I want you to review those changes (if you have a possibility to do so), as I'm not entirely sure this code is inline with your vision of how this should work.