### PR TITLE
Smart completions

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -286,10 +286,10 @@ class ST(EventListener):
         sublimeCompletions = view.extract_completions(sublimePrefix, locations[0])
 
         # preferably get prefix ourselves instead of using default sublime "prefix".
-        # Sublime will return only last portion of this preceding text
-        # given: SELECT table.col|
+        # Sublime will return only last portion of this preceding text. Given:
+        # SELECT table.col|
         # sublime will return: "col", and we need: "table.col"
-        # to know more precisely which completions are more desirable in that case
+        # to know more precisely which completions are more appropriate
 
         # get a Region that starts at the beginning of current line
         # and ends at current cursor position

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -282,8 +282,8 @@ class ST(EventListener):
         if view.match_selector(locations[0], 'string'):
             return None
 
-        sublimePrefix = prefix
-        sublimeCompletions = view.extract_completions(sublimePrefix, locations[0])
+        # sublimePrefix = prefix
+        # sublimeCompletions = view.extract_completions(sublimePrefix, locations[0])
 
         # preferably get prefix ourselves instead of using default sublime "prefix".
         # Sublime will return only last portion of this preceding text. Given:
@@ -303,8 +303,6 @@ class ST(EventListener):
             Log(e)
             pass
 
-        sql = view.substr(view.extract_scope(locations[0]))
-        print("new sql: " + sql)
         # use current paragraph as sql text to parse
         sql = view.substr(expand_to_paragraph(view, locations[0]))
 
@@ -314,9 +312,11 @@ class ST(EventListener):
         uppercaseKeywords = (keywordCase.lower() == 'upper')
 
         completion = Completion(uppercaseKeywords, ST.tables, ST.columns, ST.functions)
-        ST.autoCompleteList, inhibit = completion.getAutoCompleteList(prefix, sublimeCompletions, sql)
+        ST.autoCompleteList, inhibit = completion.getAutoCompleteList(prefix, sql)
 
-        if ST.autoCompleteList is None:
+        # safe check here, so even if we return empty completions and inhibit is true
+        # we return empty completions to show default sublime completions
+        if ST.autoCompleteList is None or len(ST.autoCompleteList) == 0:
             return None
 
         if inhibit:

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -2,6 +2,7 @@ __version__ = "v0.6.7"
 
 import sys
 import os
+import re
 from functools import partial
 
 import sublime
@@ -13,6 +14,7 @@ from .SQLToolsAPI.Log import Log, Logger
 from .SQLToolsAPI.Storage import Storage, Settings
 from .SQLToolsAPI.Connection import Connection
 from .SQLToolsAPI.History import History
+from .SQLToolsAPI.Completion import Completion
 
 USER_FOLDER                  = None
 DEFAULT_FOLDER               = None
@@ -258,56 +260,63 @@ class ST(EventListener):
 
     @staticmethod
     def on_query_completions(view, prefix, locations):
-        completions = view.extract_completions(prefix)
+        # skip completions, if no connection
+        if ST.conn is None:
+            return None
 
-        if prefix == "":
-            currentPoint = locations[0]
-            lineStartPoint = view.line(currentPoint).begin()
-            lineStartToLocation = sublime.Region(lineStartPoint, currentPoint)
-            try:
-                # everything after last space is a prefix
-                prefix = view.substr(lineStartToLocation).split(" ").pop()
-            except Exception:
-                pass
+        if not len(locations):
+            return None
 
         selectors = settings.get('selectors', [])
-        if not selectors:
-            return completions + ST.getAutoCompleteList(prefix)
-        for selector in selectors:
-            if view.match_selector(locations[0], selector):
-                return completions + ST.getAutoCompleteList(prefix)
-        return None
+        selectorMatched = False
+        if selectors:
+            for selector in selectors:
+                if view.match_selector(locations[0], selector):
+                    selectorMatched = True
+                    break
 
-    @staticmethod
-    def getAutoCompleteList(word):
-        ST.autoCompleteList = []
-        for w in ST.tables:
-            try:
-                if word.lower() in w.lower():
-                    ST.autoCompleteList.append(
-                        ("{0}\t({1})".format(w, 'Table'), w))
-            except UnicodeDecodeError:
-                continue
+        if not selectorMatched:
+            return None
 
-        for w in ST.columns:
-            try:
-                if word.lower() in w.lower():
-                    w = w.split(".")
-                    ST.autoCompleteList.append(("{0}\t({1})".format(
-                        w[1], w[0] + ' Col'), w[1]))
-            except Exception:
-                continue
+        sublimePrefix = prefix
+        sublimeCompletions = view.extract_completions(sublimePrefix, locations[0])
 
-        for w in ST.functions:
-            try:
-                if word.lower() in w.lower():
-                    ST.autoCompleteList.append(
-                        ("{0}\t({1})".format(w, 'Func'), w))
-            except Exception:
-                continue
+        print("prefix ST: " + str(sublimePrefix))
+        # don't use default sublime "prefix", get one ourselves
+        # get a Region that starts at the beginning of current line
+        # and ends at current cursor position
+        currentPoint = locations[0]
+        lineStartPoint = view.line(currentPoint).begin()
+        lineStartToLocation = sublime.Region(lineStartPoint, currentPoint)
+        try:
+            lineStr = view.substr(lineStartToLocation)
+            prefix = re.split('[^\w.]+', lineStr).pop()
+            print("prefix my: " + str(prefix))
+        except Exception as e:
+            Log(e)
+            pass
 
-        ST.autoCompleteList.sort()
-        return (ST.autoCompleteList)
+        sql = view.substr(expand_to_paragraph(view, locations[0]))
+
+        # keywords should be upper case?
+        formatSettings = settings.get('format', {})
+        keywordCase = formatSettings.get('keyword_case', 'upper')
+        uppercaseKeywords = (keywordCase.lower() == 'upper')
+
+        completion = Completion(uppercaseKeywords, ST.tables, ST.columns, ST.functions)
+        ST.autoCompleteList, inhibit = completion.getAutoCompleteList(prefix, sublimeCompletions, sql)
+
+        if ST.autoCompleteList is None:
+            return None
+
+        print("FINAL: " + str(ST.autoCompleteList))
+
+        if inhibit:
+            print("sublime.INHIBIT_WORD_COMPLETIONS")
+            return (ST.autoCompleteList, sublime.INHIBIT_WORD_COMPLETIONS)
+
+        return ST.autoCompleteList
+
 
 # #
 # # Commands
@@ -520,6 +529,7 @@ def reload():
         import imp
         imp.reload(sys.modules[__package__ + ".SQLToolsAPI"])
         imp.reload(sys.modules[__package__ + ".SQLToolsAPI.Utils"])
+        imp.reload(sys.modules[__package__ + ".SQLToolsAPI.Completion"])
         imp.reload(sys.modules[__package__ + ".SQLToolsAPI.Storage"])
         imp.reload(sys.modules[__package__ + ".SQLToolsAPI.History"])
         imp.reload(sys.modules[__package__ + ".SQLToolsAPI.Log"])

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -55,8 +55,8 @@
             "args": "-h {host} -p {port} -U {username} -d {database}",
             "queries": {
                 "desc" : {
-                    "query": "SELECT  '|' || quote_ident(n.nspname)||'.'||quote_ident(c.relname) ||'|' AS tblname FROM pg_catalog.pg_class AS c INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE relkind = 'r' AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema') ORDER BY n.nspname = current_schema() DESC, pg_catalog.pg_table_is_visible(c.oid) DESC, n.nspname, c.relname",
-                    "options": ["-t", "--no-psqlrc"],
+                    "query": "select '|' || quote_ident(table_schema)||'.'||quote_ident(table_name) ||'|' as tblname from information_schema.tables where table_schema = any(current_schemas(false)) and table_schema not in ('pg_catalog', 'information_schema') order by table_schema = current_schema() desc, table_schema, table_name",
+                    "options": ["--tuples-only", "--no-psqlrc"],
                     "format" : "|%s|"
                 },
                 "desc table": {
@@ -70,13 +70,13 @@
                     "format" : "|%s|"
                 },
                 "columns": {
-                    "query": "SELECT DISTINCT '|' || quote_ident(table_name) || '.' || quote_ident(column_name) || '|' FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA() GROUP BY table_name, column_name;",
-                    "options": ["-t", "--no-psqlrc"],
+                    "query": "select '|' || quote_ident(table_name) || '.' || quote_ident(column_name) || '|' from information_schema.columns where table_schema = any(current_schemas(false)) and table_schema not in ('pg_catalog', 'information_schema') order by table_name, ordinal_position",
+                    "options": ["--tuples-only", "--no-psqlrc"],
                     "format" : "|%s|"
                 },
                 "functions": {
-                    "query": "SELECT '|' || quote_ident(n.nspname)||'.'||quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' AS funname FROM pg_catalog.pg_proc AS f INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = f.pronamespace WHERE proisagg = false AND n.nspname NOT IN ('pg_catalog', 'information_schema')",
-                    "options": ["-t", "--no-psqlrc"],
+                    "query": "select '|' || quote_ident(n.nspname)||'.'||quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' as funname from pg_catalog.pg_proc as f inner join pg_catalog.pg_namespace as n on n.oid = f.pronamespace where f.proisagg = false and n.nspname = any(current_schemas(false)) and n.nspname not in ('pg_catalog', 'information_schema')",
+                    "options": ["--tuples-only", "--no-psqlrc"],
                     "format" : "|%s|"
                 },
                 "desc function": {
@@ -117,7 +117,12 @@
             "args": "{username}/{password}@\"(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT={port})))(CONNECT_DATA=(SERVICE_NAME={service})))\"",
             "queries": {
                 "desc" : {
-                    "query": "select CONCAT(CONCAT('| ', table_name), ' |') as tables from user_tables;",
+                    "query": "select concat(concat(concat(concat('|', owner), '.'), table_name), '|') as tbls from all_tables where owner = sys_context('USERENV', 'CURRENT_SCHEMA');",
+                    "options": ["-S"],
+                    "format" : "|%s|"
+                },
+                "columns": {
+                    "query": "select concat(concat(concat(concat('|', c.table_name), '.'), c.column_name), '|') as cols from all_tab_columns c inner join all_tables t ON c.owner = t.owner and c.table_name = t.table_name where c.owner = sys_context('USERENV', 'CURRENT_SCHEMA');",
                     "options": ["-S"],
                     "format" : "|%s|"
                 },
@@ -144,7 +149,7 @@
             "args": "-h{host} -P{port} -u\"{username}\" -p\"{password}\" -D\"{database}\"",
             "queries": {
                 "desc" : {
-                    "query": "select concat(table_schema, '.', table_name) from information_schema.tables where table_schema = database();",
+                    "query": "select concat(table_schema, '.', table_name) from information_schema.tables where table_schema = database() order by table_name;",
                     "options": ["-f", "--table", "--skip-column-names"],
                     "format" : "|%s|"
                 },
@@ -159,7 +164,7 @@
                     "format" : "|%s|"
                 },
                 "columns": {
-                    "query": "select concat(table_name, '.', column_name) from information_schema.columns where table_schema = database();",
+                    "query": "select concat(table_name, '.', column_name) from information_schema.columns where table_schema = database() order by table_name, ordinal_position;",
                     "options": ["-f", "--table", "--skip-column-names"],
                     "format" : "|%s|"
                 },
@@ -181,8 +186,13 @@
             "args": "-h {host} -p {port} -U \"{username}\" -w \"{password}\" -d \"{database}\"",
             "queries": {
                 "desc" : {
-                    "query": "\\dt",
-                    "options": ["-t"],
+                    "query": "select '|' || table_schema || '.' || table_name || '|' as tblname from v_catalog.tables where is_system_table = false",
+                    "options": ["--tuples-only", "--no-vsqlrc"],
+                    "format" : "|%s|"
+                },
+                "columns": {
+                    "query": "select '|' || table_name || '.' || column_name || '|' as tblname from v_catalog.columns where is_system_table = false order by table_name, ordinal_position",
+                    "options": ["--tuples-only", "--no-vsqlrc"],
                     "format" : "|%s|"
                 },
                 "desc table": {
@@ -208,7 +218,13 @@
             "args": "-S {host}:{port} -U\"{username}\" -P\"{password}\" -D{database}",
             "queries": {
                 "desc": {
-                    "query": "select table_name from information_schema.tables order by 1;",
+                    "query": "select concat(table_schema, '.', table_name) from information_schema.tables order by table_name;",
+                    "before" :["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""],
+                    "options": [],
+                    "format": "|%s|"
+                },
+                "columns": {
+                    "query": "select concat(table_name, '.', column_name) from information_schema.columns order by table_name, ordinal_position;",
                     "before" :["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""],
                     "options": [],
                     "format": "|%s|"

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -54,7 +54,7 @@
             "args": "-h {host} -p {port} -U {username} -d {database}",
             "queries": {
                 "desc" : {
-                    "query": "SELECT  '|' || CASE WHEN n.nspname = current_schema() THEN quote_ident(c.relname) ELSE quote_ident(n.nspname)||'.'||quote_ident(c.relname) END ||'|' AS tblname FROM pg_catalog.pg_class AS c INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE relkind = 'r' AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema') ORDER BY n.nspname = current_schema() DESC, pg_catalog.pg_table_is_visible(c.oid) DESC, n.nspname, c.relname",
+                    "query": "SELECT  '|' || quote_ident(n.nspname)||'.'||quote_ident(c.relname) ||'|' AS tblname FROM pg_catalog.pg_class AS c INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE relkind = 'r' AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema') ORDER BY n.nspname = current_schema() DESC, pg_catalog.pg_table_is_visible(c.oid) DESC, n.nspname, c.relname",
                     "options": ["-t", "--no-psqlrc"],
                     "format" : "|%s|"
                 },
@@ -74,7 +74,7 @@
                     "format" : "|%s|"
                 },
                 "functions": {
-                    "query": "SELECT '|' || CASE WHEN n.nspname = current_schema() THEN quote_ident(f.proname) ELSE quote_ident(n.nspname)||'.'||quote_ident(f.proname) END || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' AS funname FROM pg_catalog.pg_proc AS f INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = f.pronamespace WHERE proisagg = false AND n.nspname NOT IN ('pg_catalog', 'information_schema')",
+                    "query": "SELECT '|' || quote_ident(n.nspname)||'.'||quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' AS funname FROM pg_catalog.pg_proc AS f INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = f.pronamespace WHERE proisagg = false AND n.nspname NOT IN ('pg_catalog', 'information_schema')",
                     "options": ["-t", "--no-psqlrc"],
                     "format" : "|%s|"
                 },

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -12,6 +12,7 @@
      * An empty list means autocompletion always active.
      */
     "selectors": ["source.sql", "source.pgsql", "source.plpgsql.postgres", "source.plsql.oracle", "source.tsql"],
+    "autocompletion": "smart",  /* possible values: "basic", "smart" or false (disable) */
     "unescape_quotes" : [
         "php"
     ],
@@ -159,6 +160,11 @@
                 },
                 "columns": {
                     "query": "select concat(table_name, '.', column_name) from information_schema.columns where table_schema = database();",
+                    "options": ["-f", "--table", "--skip-column-names"],
+                    "format" : "|%s|"
+                },
+                "functions": {
+                    "query": "select concat(routine_schema, '.', routine_name) from information_schema.routines where routine_schema = database();",
                     "options": ["-f", "--table", "--skip-column-names"],
                     "format" : "|%s|"
                 },

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -143,7 +143,7 @@
             "args": "-h{host} -P{port} -u\"{username}\" -p\"{password}\" -D\"{database}\"",
             "queries": {
                 "desc" : {
-                    "query": "show tables",
+                    "query": "select concat(table_schema, '.', table_name) from information_schema.tables where table_schema = database();",
                     "options": ["-f", "--table", "--skip-column-names"],
                     "format" : "|%s|"
                 },
@@ -158,8 +158,8 @@
                     "format" : "|%s|"
                 },
                 "columns": {
-                    "query": "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = DATABASE();",
-                    "options": ["-f", "--table"],
+                    "query": "select concat(table_name, '.', column_name) from information_schema.columns where table_schema = database();",
+                    "options": ["-f", "--table", "--skip-column-names"],
                     "format" : "|%s|"
                 },
                 "explain plan": {

--- a/SQLToolsAPI/Completion.py
+++ b/SQLToolsAPI/Completion.py
@@ -1,0 +1,301 @@
+import string
+from collections import namedtuple
+
+# TODO: back to local import
+from .ParseUtils import extractTables
+
+# this dict is used in prefixMatchScore to remove punctuation from strings
+removePunctuationTable = str.maketrans({key: None for key in string.punctuation})
+keywords_list = ['SELECT', 'UPDATE', 'DELETE', 'INSERT', 'INTO', 'FROM',
+                 'WHERE', 'GROUP BY', 'ORDER BY', 'HAVING', 'JOIN',
+                 'INNER JOIN', 'LEFT JOIN', 'RIGHT JOIN', 'USING',
+                 'LIMIT', 'DISTINCT', 'SET']
+
+
+def _stipQuotes(ident):
+    return ident.strip('"\'`')
+
+
+class CompletionItem(namedtuple('CompletionItem', ['type', 'ident', 'score'])):
+    __slots__ = ()
+
+    @property
+    def parent(self):
+        if self.ident.count('.') == 0:
+            return None
+        else:
+            return self.ident.partition('.')[0]
+
+    @property
+    def name(self):
+        return self.ident.split('.').pop()
+
+    @property
+    def matchIdent(self):
+        if self.type == 'Function':
+            return self.ident.partition('(')[0].lower()
+        return self.ident.lower()
+
+    @property
+    def matchSublimeCompletion(self):
+        if self.type == 'Function':
+            return _stipQuotes(self.ident.split('.').pop().partition('(')[0])
+        return _stipQuotes(self.ident.split('.').pop())
+
+    def format(self):
+        typeLabel = ''
+        if self.type == 'Table':
+            typeLabel = self.type
+        elif self.type == 'Function':
+            typeLabel = 'Func'
+        elif self.type == 'Column':
+            typeLabel = 'Col'
+        elif self.type == 'Keyword':
+            typeLabel = self.type
+        elif self.type == 'Alias':
+            typeLabel = self.type
+        elif self.type == 'Unknown':
+            typeLabel = ''
+
+        if not typeLabel:
+            return ("{0}".format(self.ident), self.ident)
+
+        part = self.ident.split('.')
+        if len(part) > 1:
+            return ("{0}\t({1} {2})".format(part[1], part[0], typeLabel), part[1])
+        else:
+            return ("{0}\t({1})".format(part[0], typeLabel), part[0])
+
+    @staticmethod
+    def _stringMatched(target, search_str, exactly):
+        if exactly:
+            return target == search_str or search_str == ''
+        else:
+            if (len(search_str) == 1):
+                return target.startswith(search_str)
+            return search_str in target
+
+    def prefixMatchScore(self, search_str, exactly=False):
+        # matching parent object (before '.') exactly and
+        # matching object (after '.') as fuzzy
+        target = self.matchIdent
+        search_str = search_str.lower()
+
+        if '.' in target and '.' in search_str:
+            search_list = search_str.split('.')
+            search_object = _stipQuotes(search_list.pop())
+            search_parent = _stipQuotes(search_list.pop())
+            target_list = target.split('.')
+            target_object = _stipQuotes(target_list.pop())
+            target_parent = _stipQuotes(target_list.pop())
+            # highest score if
+            # prefix matches exactly and object is partially matches
+            if search_parent == target_parent and self._stringMatched(target_object, search_object, exactly):
+                return 1
+
+        if '.' in target:
+            target_object_noquote = _stipQuotes(target.split('.').pop())
+            search_noquote = _stipQuotes(search_str)
+            # second part matches ?
+            if self._stringMatched(target_object_noquote, search_noquote, exactly):
+                return 2
+        else:
+            target_noquote = _stipQuotes(target)
+            search_noquote = _stipQuotes(search_str)
+
+            if self._stringMatched(target_noquote, search_noquote, exactly):
+                return 3
+            else:
+                return 0
+        return 0
+
+
+class Completion:
+    def __init__(self, uppercaseKeywords, allTables, allColumns, allFunctions):
+        self.allTables = [CompletionItem('Table', table, 0) for table in allTables]
+        self.allColumns = [CompletionItem('Column', column, 0) for column in allColumns]
+        self.allFunctions = [CompletionItem('Function', func, 0) for func in allFunctions]
+
+        self.allKeywords = []
+        for keyword in keywords_list:
+            if uppercaseKeywords:
+                keyword = keyword.upper()
+            else:
+                keyword = keyword.lower()
+
+            self.allKeywords.append(CompletionItem('Keyword', keyword, 0))
+
+    def getAutoCompleteList(self, prefix, sublimeCompletions, sql):
+        # TODO: add completions of function out fields
+        prefix = prefix.lower()
+        prefix_dots = prefix.count('.')
+
+        identifiers = extractTables(sql)
+        print("identifiers: " + str(identifiers))
+
+        autocompleteList = []
+        inhibit = False
+        if prefix_dots == 0:
+            autocompleteList, inhibit = self._noDotsCompletions(prefix, sublimeCompletions, identifiers)
+        elif prefix_dots == 1:
+            autocompleteList, inhibit = self._singleDotCompletions(prefix, sublimeCompletions, identifiers)
+        else:
+            autocompleteList, inhibit = self._multiDotCompletions(prefix, sublimeCompletions, identifiers)
+
+        if autocompleteList is not None and len(autocompleteList) > 0:
+            autocompleteList = [item.format() for item in autocompleteList]
+            return autocompleteList, inhibit
+
+        return None, False
+
+    def _noDotsCompletions(self, prefix, sublimeCompletions, identifiers):
+        # output aliases first, then
+        # output columns related to current statement, then
+        # search for columns, tables, functions with prefix
+
+        # use set, as we are interested only in unique idetifiers
+        sql_aliases = set()
+        sql_tables = set()
+        sql_columns = set()
+        sql_functions = set()
+
+        for ident in identifiers:
+            if ident.has_alias():
+                    sql_aliases.add(CompletionItem('Alias', ident.alias, 0))
+
+            if ident.is_function:
+                functions = [fun for fun in self.allFunctions if fun.prefixMatchScore(ident.full_name, exactly=True) > 0]
+                sql_functions.update(functions)
+            else:
+                tables = [table for table in self.allTables if table.prefixMatchScore(ident.full_name, exactly=True) > 0]
+                sql_tables.update(tables)
+                prefix_for_column_match = ident.name + '.'
+                columns = [col for col in self.allColumns if col.prefixMatchScore(prefix_for_column_match, exactly=True) > 0]
+                sql_columns.update(columns)
+
+        autocompleteList = []
+
+        for item in sql_aliases:
+            score = item.prefixMatchScore(prefix)
+            if score and item.ident != prefix:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in sql_columns:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in sql_tables:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in sql_functions:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in self.allKeywords:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        # if len(autocompleteList) > 0:
+        #     print("thats it: " + str(autocompleteList))
+        #     return autocompleteList, True
+
+        # #############################################
+        for item in self.allColumns:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                if item not in sql_columns:
+                    autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in self.allTables:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                if item not in sql_tables:
+                    autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in self.allFunctions:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                if item not in sql_functions:
+                    autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        return autocompleteList, False
+
+    def _singleDotCompletions(self, prefix, sublimeCompletions, identifiers):
+        prefix_list = prefix.split(".")
+        prefix_obj = prefix_list.pop()
+        prefix_ref = prefix_list.pop()
+
+        sql_table_aliases = set()
+        sql_query_aliases = set()
+
+        # we use set, as we are interested only in unique idetifiers
+        for ident in identifiers:
+            if ident.has_alias() and ident.alias == prefix_ref:
+                if ident.is_query_alias:
+                    sql_query_aliases.add(ident.alias)
+
+                if ident.is_table_alias:
+                    tables = [(ident.alias, table) for table in self.allTables if table.prefixMatchScore(ident.full_name, exactly=True) > 0]
+                    sql_table_aliases.update(tables)
+
+        autocompleteList = []
+
+        for alias, table_item in sql_table_aliases:
+            prefix_to_match = table_item.name + '.' + prefix_obj
+            for item in self.allColumns:
+                score = item.prefixMatchScore(prefix_to_match)
+                if score:
+                    autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in self.allColumns:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in self.allTables:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        for item in self.allFunctions:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        inhibit = True
+        if prefix_ref in sql_query_aliases:
+            inhibit = False
+
+        return autocompleteList, inhibit
+
+    def _multiDotCompletions(self, prefix, sublimeCompletions, identifiers):
+        # prefix_list = prefix.split(".")
+        # prefix_obj = _stipQuotes(prefix_list.pop())
+        # prefix_ref = _stipQuotes(prefix_list.pop())
+        # prefix = prefix_ref + '.' + prefix_obj
+        print("match columns only, new prefix: " + prefix)
+
+        autocompleteList = []
+        for item in self.allColumns:
+            score = item.prefixMatchScore(prefix)
+            if score:
+                autocompleteList.append(CompletionItem(item.type, item.ident, score))
+
+        if len(autocompleteList) > 0:
+            return autocompleteList, True
+
+        return None, False
+
+# itm = CompletionItem('Function', 'common.testing()');
+# print(str(itm))
+# print(str(itm.parent))
+# print(str(itm.name))
+# print(str(itm.matchIdent))
+# print(str(itm.matchSublimeCompletion))
+# print(str(itm.prefixMatchScore('common.test')))
+# print(str(itm.format()))

--- a/SQLToolsAPI/Completion.py
+++ b/SQLToolsAPI/Completion.py
@@ -1,4 +1,3 @@
-import string
 import re
 from collections import namedtuple
 
@@ -56,14 +55,12 @@ class CompletionItem(namedtuple('CompletionItem', ['type', 'ident', 'score'])):
             return self.ident.partition('(')[0].lower()
         return self.ident.lower()
 
-    """
-    Helper method for string matching
-    When exactly is true:
-      matches search string to target exactly, but empty search string matches anything
-    When exactly is false:
-      if only one char given in search string match this single char with start
-      of target string, otherwise match search string anywhere in target string
-    """
+    # Helper method for string matching
+    # When exactly is true:
+    #   matches search string to target exactly, but empty search string matches anything
+    # When exactly is false:
+    #   if only one char given in search string match this single char with start
+    #   of target string, otherwise match search string anywhere in target string
     @staticmethod
     def _stringMatched(target, search, exactly):
         if exactly:
@@ -73,16 +70,14 @@ class CompletionItem(namedtuple('CompletionItem', ['type', 'ident', 'score'])):
                 return target.startswith(search)
             return search in target
 
-    """
-    Method to match completion item against search string (prefix).
-    Lower score means a better match.
-    If completion item matches prefix with parent identifier, e.g.:
-        table_name.column ~ table_name.co, then score = 1
-    If completion item matches prefix without parent identifier, e.g.:
-        table_name.column ~ co, then score = 2
-    If completion item matches, but prefix has no parent, e.g.:
-        table ~ tab, then score = 3
-    """
+    # Method to match completion item against search string (prefix).
+    # Lower score means a better match.
+    # If completion item matches prefix with parent identifier, e.g.:
+    #     table_name.column ~ table_name.co, then score = 1
+    # If completion item matches prefix without parent identifier, e.g.:
+    #     table_name.column ~ co, then score = 2
+    # If completion item matches, but prefix has no parent, e.g.:
+    #     table ~ tab, then score = 3
     def prefixMatchScore(self, search, exactly=False):
         target = self._matchIdent()
         search = search.lower()
@@ -224,7 +219,6 @@ class Completion:
                     joinAlias = joinCondMatch.group(1)
             except Exception as e:
                 print(e)
-                pass
 
         autocompleteList = []
         inhibit = False
@@ -264,7 +258,7 @@ class Completion:
 
         for ident in identifiers:
             if ident.has_alias():
-                    sqlAliases.add(CompletionItem('Alias', ident.alias, 0))
+                sqlAliases.add(CompletionItem('Alias', ident.alias, 0))
 
             if ident.is_function:
                 functions = [
@@ -366,7 +360,7 @@ class Completion:
 
                 if ident.is_table_alias:
                     tables = [
-                        (ident.alias, table)
+                        table
                         for table in self.allTables
                         if table.prefixMatchScore(ident.full_name, exactly=True) > 0
                     ]
@@ -383,7 +377,7 @@ class Completion:
         # first of all expand table aliases to real table names and try
         # to match their columns with prefix of these expanded identifiers
         # e.g. select x.co| from tab x   //  "x.co" will expland to "tab.co"
-        for alias, table_item in sqlTableAliases:
+        for table_item in sqlTableAliases:
             prefix_to_match = table_item.name + '.' + prefixObject
             for item in self.allColumns:
                 score = item.prefixMatchScore(prefix_to_match)

--- a/SQLToolsAPI/Completion.py
+++ b/SQLToolsAPI/Completion.py
@@ -126,12 +126,23 @@ class Completion:
             self.allKeywords.append(CompletionItem('Keyword', keyword, 0))
 
     def getAutoCompleteList(self, prefix, sublimeCompletions, sql):
+        """
+        Since it's too complicated to handle the specifics of identifiers case sensivity
+        as well as all nuances of quoting of those identifiers for each RDBMS, we always
+        match against lower-cased and stripped quotes of both prefix and our internal saved
+        identifiers (tables, columns, functions). E.g. "MyTable"."myCol" --> mytable.mycol
+        """
+
         # TODO: add completions of function out fields
         prefix = prefix.lower()
         prefix_dots = prefix.count('.')
 
-        identifiers = extractTables(sql)
-        print("identifiers: " + str(identifiers))
+        # continue with empty identifiers list, even if we failed to parse identifiers
+        identifiers = []
+        try:
+            identifiers = extractTables(sql)
+        except Exception as e:
+            print(e)
 
         autocompleteList = []
         inhibit = False

--- a/SQLToolsAPI/ParseUtils.py
+++ b/SQLToolsAPI/ParseUtils.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import itertools
+from collections import namedtuple
+
+dirpath = os.path.join(os.path.dirname(__file__), 'lib')
+if dirpath not in sys.path:
+    sys.path.append(dirpath)
+
+import sqlparse
+
+from sqlparse.sql import IdentifierList, Identifier, Function
+from sqlparse.tokens import Keyword, DML
+
+
+class Reference(namedtuple('Reference', ['schema', 'name', 'alias', 'is_function'])):
+    __slots__ = ()
+
+    def has_alias(self):
+        return self.alias is not None
+
+    @property
+    def is_query_alias(self):
+        return self.name is None and self.alias is not None
+
+    @property
+    def is_table_alias(self):
+        return self.name is not None and self.alias is not None and not self.is_function
+
+    @property
+    def full_name(self):
+        if self.schema is None:
+            return self.name
+        else:
+            return self.schema + '.' + self.name
+
+
+def _is_subselect(parsed):
+    if not parsed.is_group:
+        return False
+    for item in parsed.tokens:
+        if item.ttype is DML and item.value.upper() in ('SELECT', 'INSERT',
+                                                        'UPDATE', 'CREATE', 'DELETE'):
+            return True
+    return False
+
+
+def _identifier_is_function(identifier):
+    return any(isinstance(t, Function) for t in identifier.tokens)
+
+
+def _extract_from_part(parsed):
+    tbl_prefix_seen = False
+    for item in parsed.tokens:
+        if item.is_group:
+            for x in _extract_from_part(item):
+                yield x
+        if tbl_prefix_seen:
+            if _is_subselect(item):
+                for x in _extract_from_part(item):
+                    yield x
+            # An incomplete nested select won't be recognized correctly as a
+            # sub-select. eg: 'SELECT * FROM (SELECT id FROM user'. This causes
+            # the second FROM to trigger this elif condition resulting in a
+            # StopIteration. So we need to ignore the keyword if the keyword
+            # FROM.
+            # Also 'SELECT * FROM abc JOIN def' will trigger this elif
+            # condition. So we need to ignore the keyword JOIN and its variants
+            # INNER JOIN, FULL OUTER JOIN, etc.
+            elif item.ttype is Keyword and (
+                    not item.value.upper() == 'FROM') and (
+                    not item.value.upper().endswith('JOIN')):
+                tbl_prefix_seen = False
+            else:
+                yield item
+        elif item.ttype is Keyword or item.ttype is Keyword.DML:
+            item_val = item.value.upper()
+            if (item_val in ('COPY', 'FROM', 'INTO', 'UPDATE', 'TABLE') or
+                    item_val.endswith('JOIN')):
+                tbl_prefix_seen = True
+        # 'SELECT a, FROM abc' will detect FROM as part of the column list.
+        # So this check here is necessary.
+        elif isinstance(item, IdentifierList):
+            for identifier in item.get_identifiers():
+                if (identifier.ttype is Keyword and
+                        identifier.value.upper() == 'FROM'):
+                    tbl_prefix_seen = True
+                    break
+
+
+def _extract_table_identifiers(token_stream):
+    for item in token_stream:
+        if isinstance(item, IdentifierList):
+            for ident in item.get_identifiers():
+                try:
+                    alias = ident.get_alias()
+                    schema_name = ident.get_parent_name()
+                    real_name = ident.get_real_name()
+                except AttributeError:
+                    continue
+                if real_name:
+                    yield Reference(schema_name, real_name,
+                                    alias, _identifier_is_function(ident))
+        elif isinstance(item, Identifier):
+            yield Reference(item.get_parent_name(), item.get_real_name(),
+                            item.get_alias(), _identifier_is_function(item))
+        elif isinstance(item, Function):
+            yield Reference(item.get_parent_name(), item.get_real_name(),
+                            item.get_alias(), _identifier_is_function(item))
+
+
+def extractTables(sql):
+    # let's handle multiple statements in one sql string
+    extracted_tables = []
+    statements = list(sqlparse.parse(sql))
+    for statement in statements:
+        stream = _extract_from_part(statement)
+        extracted_tables.append(list(_extract_table_identifiers(stream)))
+    return list(itertools.chain(*extracted_tables))

--- a/SQLToolsAPI/Utils.py
+++ b/SQLToolsAPI/Utils.py
@@ -56,11 +56,11 @@ def saveJson(content, filename):
 def getResultAsList(results):
     resultList = []
     for result in results.splitlines():
-        try:
-            resultList.append(result.split('|')[1].strip())
-        except IndexError:
-            pass
-
+        lineResult = ''
+        for element in result.strip('|').split('|'):
+            lineResult += element.strip()
+        if lineResult:
+            resultList.append(lineResult)
     return resultList
 
 

--- a/SQLToolsAPI/__init__.py
+++ b/SQLToolsAPI/__init__.py
@@ -4,6 +4,7 @@ __version__ = "v0.2.5"
 __all__ = [
     'Log',
     'Utils',
+    'Completion',
     'Command',
     'Connection',
     'History',


### PR DESCRIPTION
New "smarter" completions are shown, when possible.
The main difference from previous completions are proper completions for table columns: `table.column|`, as well as completions for table aliases:
`select a.| from tbl a`
and completions for join conditions:
`select * from tbl_a a inner join tbl_b b on |`
The current paragraph of SQL text is parsed by already existing `sqlparse` library.
A small demo can be seen in discussion https://github.com/mtxr/SQLTools/issues/67