### PR TITLE
Use stream output for saved queries and history

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -502,7 +502,8 @@ class StHistory(WindowCommand):
         def cb(index):
             if index < 0:
                 return None
-            return ST.conn.execute(history.get(index), createOutput())
+            return ST.conn.execute(history.get(index), createOutput(),
+                                   stream=settings.get('use_streams', False))
 
         Window().show_quick_panel(history.all(), cb)
 
@@ -538,9 +539,14 @@ class StListQueries(WindowCommand):
             if index < 0:
                 return None
 
-            param2 = createOutput() if mode == "run" else options[index][0]
-            func = ST.conn.execute if mode == "run" else toNewTab
-            return func(options[index][1], param2)
+            alias, query = options[index]
+            if mode == "run":
+                ST.conn.execute(query, createOutput(),
+                                stream=settings.get('use_streams', False))
+            else:
+                toNewTab(query, alias)
+
+            return
 
         try:
             Window().show_quick_panel(options, cb)

--- a/SQLToolsAPI/Command.py
+++ b/SQLToolsAPI/Command.py
@@ -61,7 +61,8 @@ class Command(object):
 
             queryTimerEnd = time.time()
             # we are done with the output, terminate the process
-            self.process.terminate()
+            if self.process:
+                self.process.terminate()
 
             if 'show_query' in self.options and self.options['show_query']:
                 formattedQueryInfo = self._formatShowQuery(self.query, queryTimerStart, queryTimerEnd)


### PR DESCRIPTION
Honor `use_streams` setting when executing saved queries and queries from history.

Additionally, on MacOS the process is set to `None` after all of the output has been processed, so add the additional check for that in Command code.