### PR TITLE
Fixed "clear_output" for panel output

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -140,7 +140,9 @@ def toNewTab(content, name="", suffix="SQLTools Saved Query"):
 
 def getOutputPlace(syntax=None, name="SQLTools Result"):
     if not settings.get('show_result_on_window', True):
-        resultContainer = Window().create_output_panel(name)
+        resultContainer = Window().find_output_panel(name)
+        if resultContainer is None:
+            resultContainer = Window().create_output_panel(name)
         Window().run_command("show_panel", {"panel": "output." + name})
     else:
         resultContainer = None

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -6,7 +6,7 @@
     "thread_timeout"        : 15,     // query timeout in seconds
     "history_size"          : 100,
     "show_result_on_window" : false,
-    "clear_output"          : false,
+    "clear_output"          : true,
     "safe_limit"            : false,
     "show_query"            : false,
     "expand_to_paragraph"   : false,


### PR DESCRIPTION
Fixed "clear_output" for panel output.
Also, the default for setting "clear_output" is set to true, so it is consistent with previous behavior.

Fix for #102