### PR TITLE
Add Execute All File command

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+a"], "command": "st_execute_all" },
     { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
@@ -9,6 +10,6 @@
     { "keys": ["ctrl+e", "ctrl+b"], "command": "st_format" },
     { "keys": ["ctrl+e", "ctrl+q"], "command": "st_save_query" },
     { "keys": ["ctrl+e", "ctrl+r"], "command": "st_remove_saved_query" },
-    { "keys": ["ctrl+e", "ctrl+a"], "command": "st_list_queries"},
+    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries"},
     { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+super+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+a"], "command": "st_execute_all" },
     { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
@@ -9,6 +10,6 @@
     { "keys": ["ctrl+e", "ctrl+b"], "command": "st_format" },
     { "keys": ["ctrl+e", "ctrl+q"], "command": "st_save_query" },
     { "keys": ["ctrl+e", "ctrl+r"], "command": "st_remove_saved_query" },
-    { "keys": ["ctrl+e", "ctrl+a"], "command": "st_list_queries"},
+    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries"},
     { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+alt+e"], "command": "st_select_connection" },
     { "keys": ["ctrl+e", "ctrl+e"], "command": "st_execute" },
+    { "keys": ["ctrl+e", "ctrl+a"], "command": "st_execute_all" },
     { "keys": ["ctrl+e", "ctrl+x"], "command": "st_explain_plan" },
     { "keys": ["ctrl+e", "ctrl+h"], "command": "st_history" },
     { "keys": ["ctrl+e", "ctrl+s"], "command": "st_show_records" },
@@ -9,6 +10,6 @@
     { "keys": ["ctrl+e", "ctrl+b"], "command": "st_format" },
     { "keys": ["ctrl+e", "ctrl+q"], "command": "st_save_query" },
     { "keys": ["ctrl+e", "ctrl+r"], "command": "st_remove_saved_query" },
-    { "keys": ["ctrl+e", "ctrl+a"], "command": "st_list_queries"},
+    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries"},
     { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,6 +8,10 @@
     "command": "st_execute"
   },
   {
+    "caption": "ST: Execute All File",
+    "command": "st_execute_all"
+  },
+  {
     "caption": "ST: Explain Plan",
     "command": "st_explain_plan"
   },

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -473,6 +473,18 @@ class StExecute(WindowCommand):
         ST.conn.execute(getSelection(), createOutput(), stream=settings.get('use_streams', False))
 
 
+class StExecuteAll(WindowCommand):
+    @staticmethod
+    def run():
+        if not ST.conn:
+            ST.selectConnection(tablesCallback=lambda: Window().run_command('st_execute_all'))
+            return
+
+        Window().status_message(MESSAGE_RUNNING_CMD)
+        allText = View().substr(sublime.Region(0, View().size()))
+        ST.conn.execute(allText, createOutput(), stream=settings.get('use_streams', False))
+
+
 class StFormat(TextCommand):
     @staticmethod
     def run(edit):


### PR DESCRIPTION
Added Execute All File command.

Minor key binding change:
`Execute All File` command got a key binding `ctrl+e ctrl+a`, which overlapped with `List Queries`.

Instead of rarely used `List Queries` (`ctrl+e ctrl+a`) which is now set by default to (`ctrl+e ctrl+l`) for better mnemonic (list).

Fixes #114 