### PR TITLE
Fix List and Open Saved Queries

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -536,8 +536,9 @@ class StSaveQuery(WindowCommand):
 class StListQueries(WindowCommand):
     @staticmethod
     def run(mode="run"):
-        if not ST.conn:
-            ST.selectConnection(functionsCallback=lambda: Window().run_command('st_list_queries'))
+        if mode == "run" and not ST.conn:
+            ST.selectConnection(functionsCallback=lambda: Window().run_command('st_list_queries',
+                                                                               {'mode': mode}))
             return
 
         queriesList = queries.all()


### PR DESCRIPTION
Fixes #125.

Since we actually don't need the connection if the user just opens the contents of saved query the Connection list will not be shown.