### PR TITLE
Add List and Insert Saved Queries

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -11,5 +11,6 @@
     { "keys": ["ctrl+e", "ctrl+q"], "command": "st_save_query" },
     { "keys": ["ctrl+e", "ctrl+r"], "command": "st_remove_saved_query" },
     { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries"},
-    { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}}
+    { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}},
+    { "keys": ["ctrl+e", "ctrl+i"], "command": "st_list_queries", "args": {"mode" : "insert"}}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -54,6 +54,11 @@
     "args"   :  {"mode": "open"}
   },
   {
+    "caption": "ST: List and Insert Saved Queries",
+    "command": "st_list_queries",
+    "args"   :  {"mode": "insert"}
+  },
+  {
     "caption": "ST: Format Current SQL File",
     "command": "st_format"
   },

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -141,10 +141,15 @@ def toNewTab(content, name="", suffix="SQLTools Saved Query"):
 
 def insertContent(content):
     view = View()
+    # getting the settings local to this view/tab
     settings = view.settings()
+    # saving the original settings for "auto_indent", or True if none set
     autoIndent = settings.get('auto_indent', True)
+    # turn off automatic indenting otherwise the tabbing of the original
+    # string is not respected after a newline is encountered
     settings.set('auto_indent', False)
     view.run_command('insert', {'characters': content})
+    # restore "auto_indent" setting
     settings.set('auto_indent', autoIndent)
 
 

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -139,6 +139,11 @@ def toNewTab(content, name="", suffix="SQLTools Saved Query"):
     resultContainer.run_command('append', {'characters': content})
 
 
+def insertContent(content):
+    currentView = View()
+    currentView.run_command('insert', {'characters': content})
+
+
 def getOutputPlace(syntax=None, name="SQLTools Result"):
     if not settings.get('show_result_on_window', True):
         resultContainer = Window().find_output_panel(name)
@@ -559,6 +564,8 @@ class StListQueries(WindowCommand):
             if mode == "run":
                 ST.conn.execute(query, createOutput(),
                                 stream=settings.get('use_streams', False))
+            elif mode == "insert":
+                insertContent(query);
             else:
                 toNewTab(query, alias)
 

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -140,8 +140,12 @@ def toNewTab(content, name="", suffix="SQLTools Saved Query"):
 
 
 def insertContent(content):
-    currentView = View()
-    currentView.run_command('insert', {'characters': content})
+    view = View()
+    settings = view.settings()
+    autoIndent = settings.get('auto_indent', True)
+    settings.set('auto_indent', False)
+    view.run_command('insert', {'characters': content})
+    settings.set('auto_indent', autoIndent)
 
 
 def getOutputPlace(syntax=None, name="SQLTools Result"):
@@ -565,7 +569,7 @@ class StListQueries(WindowCommand):
                 ST.conn.execute(query, createOutput(),
                                 stream=settings.get('use_streams', False))
             elif mode == "insert":
-                insertContent(query);
+                insertContent(query)
             else:
                 toNewTab(query, alias)
 


### PR DESCRIPTION
As described in issue #126, added the ability to insert saved queries directly into existing tab at the current selection(s). Try it out and let me know what you think. I'll update the website once the green light is given.

This new feature expands the `st_list_queries` command to take a new argument for mode: "insert" which will perform the insertion of a selected saved query.
The keybind for this feature is currently mapped to `Ctrl+E, Ctrl+I`.