### PR TITLE
Better messages if settings could not be parsed

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -57,9 +57,21 @@ def startPlugin():
     QUERIES_FILENAME             = os.path.join(USER_FOLDER, SQLTOOLS_QUERIES_FILE)
     QUERIES_FILENAME_DEFAULT     = os.path.join(DEFAULT_FOLDER, SQLTOOLS_QUERIES_FILE)
 
-    settings    = Settings(SETTINGS_FILENAME, default=SETTINGS_FILENAME_DEFAULT)
+    try:
+        settings    = Settings(SETTINGS_FILENAME, default=SETTINGS_FILENAME_DEFAULT)
+    except Exception as e:
+        msg = __package__ + ": Failed to parse " + SQLTOOLS_SETTINGS_FILE + " file"
+        print(msg + "\nError: " + str(e))
+        Window().status_message(msg)
+
+    try:
+        connections = Settings(CONNECTIONS_FILENAME, default=CONNECTIONS_FILENAME_DEFAULT)
+    except Exception as e:
+        msg = __package__ + ": Failed to parse " + SQLTOOLS_CONNECTIONS_FILE + " file"
+        print(msg + "\nError: " + str(e))
+        Window().status_message(msg)
+
     queries     = Storage(QUERIES_FILENAME, default=QUERIES_FILENAME_DEFAULT)
-    connections = Settings(CONNECTIONS_FILENAME, default=CONNECTIONS_FILENAME_DEFAULT)
     history     = History(settings.get('history_size', 100))
 
     Logger.setPackageVersion(__version__)


### PR DESCRIPTION
SQLTools will display a shorter and more appropriate error message in the
status bar and in the console if SQLTools failed to parse Settings and
Connections JSON files.