### PR TITLE
Fix completions for identifiers with dollar sign

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -368,7 +368,7 @@ class ST(EventListener):
         lineStartToLocation = sublime.Region(lineStartPoint, currentPoint)
         try:
             lineStr = view.substr(lineStartToLocation)
-            prefix = re.split('[^`\"\w.]+', lineStr).pop()
+            prefix = re.split('[^`\"\w.\$]+', lineStr).pop()
         except Exception as e:
             Log(e)
 

--- a/SQLToolsAPI/Completion.py
+++ b/SQLToolsAPI/Completion.py
@@ -39,6 +39,11 @@ def _stripPrefix(text, prefix):
     return text
 
 
+# escape $ sign when formatting output
+def _escapeDollarSign(ident):
+    return ident.replace("$", "\$")
+
+
 class CompletionItem(namedtuple('CompletionItem', ['type', 'ident'])):
     """
     Represents a potential or actual completion item.
@@ -149,10 +154,10 @@ class CompletionItem(namedtuple('CompletionItem', ['type', 'ident'])):
         part = self.ident.split('.')
         if len(part) > 1:
             return ("{0}\t({1} {2})".format(part[1], part[0], typeDisplay),
-                    _stripQuotesOnDemand(part[1], stripQuotes))
+                    _stripQuotesOnDemand(_escapeDollarSign(part[1]), stripQuotes))
 
         return ("{0}\t({1})".format(self.ident, typeDisplay),
-                _stripQuotesOnDemand(self.ident, stripQuotes))
+                _stripQuotesOnDemand(_escapeDollarSign(self.ident), stripQuotes))
 
 
 class Completion:


### PR DESCRIPTION
Dolar sign is treated as part of an identifier when evaluating autocompletion prefix.
Dolar sign is escaped when formatting autocompletion items (otherwise Sublime Text assumes it a variable).

Fixes #152 