### PR TITLE
Add MSSQL support, unify and fix "before" & "after" sql config, review most RDBMS configs

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -497,7 +497,7 @@ class StExecute(WindowCommand):
             return
 
         Window().status_message(MESSAGE_RUNNING_CMD)
-        ST.conn.execute(getSelection(), createOutput(), stream=settings.get('use_streams', False))
+        ST.conn.execute(getSelection(), createOutput())
 
 
 class StExecuteAll(WindowCommand):
@@ -509,7 +509,7 @@ class StExecuteAll(WindowCommand):
 
         Window().status_message(MESSAGE_RUNNING_CMD)
         allText = View().substr(sublime.Region(0, View().size()))
-        ST.conn.execute(allText, createOutput(), stream=settings.get('use_streams', False))
+        ST.conn.execute(allText, createOutput())
 
 
 class StFormat(TextCommand):
@@ -543,8 +543,7 @@ class StHistory(WindowCommand):
         def cb(index):
             if index < 0:
                 return None
-            return ST.conn.execute(history.get(index), createOutput(),
-                                   stream=settings.get('use_streams', False))
+            return ST.conn.execute(history.get(index), createOutput())
 
         Window().show_quick_panel(history.all(), cb)
 
@@ -583,8 +582,7 @@ class StListQueries(WindowCommand):
 
             alias, query = options[index]
             if mode == "run":
-                ST.conn.execute(query, createOutput(),
-                                stream=settings.get('use_streams', False))
+                ST.conn.execute(query, createOutput())
             elif mode == "insert":
                 insertContent(query)
             else:

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -68,6 +68,7 @@
         "pgsql": {
             "options": ["--no-password"],
             "before": [],
+            "after": [],
             "args": "-h {host} -p {port} -U {username} -d {database}",
             "env_optional": {
                 "PGPASSWORD": "{password}"
@@ -126,6 +127,7 @@
                 "SET VERIFY         OFF ",
                 "SET WRAP           OFF"
             ],
+            "after": [],
             "args": "{username}/{password}@\"(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT={port})))(CONNECT_DATA=(SERVICE_NAME={service})))\"",
             "queries": {
                 "desc" : {
@@ -153,6 +155,7 @@
         "mysql": {
             "options": ["-f", "--table", "--default-character-set=utf8"],
             "before": [],
+            "after": [],
             "args": "-h{host} -P{port} -u\"{username}\" -D\"{database}\"",
             "args_optional": ["--login-path=\"{login-path}\"", "--defaults-extra-file=\"{defaults-extra-file}\"", "-p\"{password}\""],
             "queries": {
@@ -189,6 +192,7 @@
         "mssql": {
             "options": [],
             "before": [],
+            "after": ["GO", "QUIT"],
             "args": "-d \"{database}\"",
             "args_optional": ["-S \"{host},{port}\"", "-S \"{host}\\{instance}\"", "-U \"{username}\"", "-P \"{password}\""],
             "queries": {
@@ -213,6 +217,7 @@
         "vertica": {
             "options": [],
             "before" : [],
+            "after": [],
             "args": "-h {host} -p {port} -U \"{username}\" -w \"{password}\" -d \"{database}\"",
             "queries": {
                 "desc" : {
@@ -240,6 +245,7 @@
         "sqsh": {
             "options": [],
             "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""],
+            "after": [],
             "args": "-S {host}:{port} -U\"{username}\" -P\"{password}\" -D{database}",
             "queries": {
                 "desc": {
@@ -267,6 +273,7 @@
         "sqlite": {
             "options": ["-column", "-header"],
             "before": [],
+            "after": [],
             "args": "\"{database}\"",
             "queries": {
                 "desc" : {
@@ -290,6 +297,7 @@
         "firebird": {
             "options": [],
             "before": [],
+            "after": [],
             "args": "-u \"{username}\" -p \"{password}\" \"{host}/{port}:{database}\"",
             "queries": {
                 "desc" : {

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -74,33 +74,36 @@
                 "PGPASSWORD": "{password}"
             },
             "queries": {
-                "desc" : {
+                "exec": {
+                    "options": []
+                },
+                "desc": {
                     "query": "select '|' || quote_ident(table_schema)||'.'||quote_ident(table_name) ||'|' as tblname from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema') order by table_schema = current_schema() desc, table_schema, table_name",
                     "options": ["--tuples-only", "--no-psqlrc"]
                 },
                 "desc table": {
-                    "query": "\\d+ %s",
-                    "options": ["--no-password"]
+                    "query": "\\d+ {0}",
+                    "options": []
                 },
                 "show records": {
                     "query": "select * from {0} limit {1}",
-                    "options": ["--no-password"]
+                    "options": []
                 },
                 "columns": {
                     "query": "select '|' || quote_ident(table_name) || '.' || quote_ident(column_name) || '|' from information_schema.columns where table_schema not in ('pg_catalog', 'information_schema') order by table_name, ordinal_position",
-                    "options": ["--no-password", "--tuples-only", "--no-psqlrc"]
+                    "options": ["--tuples-only", "--no-psqlrc"]
                 },
                 "functions": {
                     "query": "select '|' || quote_ident(n.nspname)||'.'||quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' as funname from pg_catalog.pg_proc as f inner join pg_catalog.pg_namespace as n on n.oid = f.pronamespace where f.proisagg = false and n.nspname not in ('pg_catalog', 'information_schema')",
-                    "options": ["--no-password", "--tuples-only", "--no-psqlrc"]
+                    "options": ["--tuples-only", "--no-psqlrc"]
                 },
                 "desc function": {
-                    "query": "\\sf %s",
-                    "options": ["--no-password"]
+                    "query": "\\sf {0}",
+                    "options": []
                 },
                 "explain plan": {
                     "query": "explain {0};",
-                    "options": ["--no-password"]
+                    "options": []
                 }
             }
         },
@@ -130,62 +133,68 @@
             "after": [],
             "args": "{username}/{password}@\"(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT={port})))(CONNECT_DATA=(SERVICE_NAME={service})))\"",
             "queries": {
+                "exec": {
+                    "options": []
+                },
                 "desc" : {
                     "query": "select concat(concat(concat(concat('|', owner), '.'), table_name), '|') as tbls from all_tables UNION ALL select concat(concat(concat(concat('|', owner), '.'), view_name), '|') as tbls from all_views;",
-                    "options": ["-S"]
+                    "options": []
                 },
                 "columns": {
                     "query": "SELECT concat(concat(concat(concat('|', c.table_name), '.'), c.column_name), '|') AS cols FROM all_tab_columns c INNER JOIN all_tables t ON c.owner = t.owner AND c.table_name = t.table_name UNION ALL SELECT concat(concat(concat(concat('|', c.table_name), '.'), c.column_name), '|') AS cols FROM all_tab_columns c INNER JOIN all_views t ON c.owner = t.owner AND c.table_name = t.view_name;",
-                    "options": ["-S"]
+                    "options": []
                 },
                 "desc table": {
-                    "query": "desc %s;",
-                    "options": ["-S"]
+                    "query": "desc {0};",
+                    "options": []
                 },
                 "show records": {
                     "query": "select * from {0} WHERE ROWNUM <= {1};",
-                    "options": ["-S"]
+                    "options": []
                 },
                 "explain plan": {
                     "query": "explain plan for {0};\nselect plan_table_output from table(dbms_xplan.display());",
-                    "options": ["-S"]
+                    "options": []
                 }
             }
         },
         "mysql": {
-            "options": ["-f", "--table", "--default-character-set=utf8"],
+            "options": ["--default-character-set=utf8"],
             "before": [],
             "after": [],
             "args": "-h{host} -P{port} -u\"{username}\" -D\"{database}\"",
             "args_optional": ["--login-path=\"{login-path}\"", "--defaults-extra-file=\"{defaults-extra-file}\"", "-p\"{password}\""],
             "queries": {
+                "exec": {
+                    "options": ["--table", "-f"]
+                },
                 "desc" : {
                     "query": "select concat('|', case when table_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_schema,'`') else table_schema end, '.', case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end, '|') from information_schema.tables where table_schema = database() order by table_name;",
-                    "options": ["-f", "--silent", "--raw", "--default-character-set=utf8"]
+                    "options": ["--silent", "--raw"]
                 },
                 "desc table": {
-                    "query": "desc %s",
-                    "options": ["-f", "--table", "--default-character-set=utf8"]
+                    "query": "desc {0}",
+                    "options": ["--table"]
                 },
                 "show records": {
                     "query": "select * from {0} limit {1}",
-                    "options": ["-f", "--table", "--default-character-set=utf8"]
+                    "options": ["--table"]
                 },
                 "columns": {
                     "query": "select concat('|',  case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end, '.', case when column_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',column_name,'`') else column_name end, '|') from information_schema.columns where table_schema = database() order by table_name, ordinal_position;",
-                    "options": ["-f", "--silent", "--raw", "--default-character-set=utf8"]
+                    "options": ["--silent", "--raw"]
                 },
                 "functions": {
                     "query": "select concat('|', case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end, '()', '|') from information_schema.routines where routine_schema = database();",
-                    "options": ["-f", "--silent", "--raw", "--default-character-set=utf8"]
+                    "options": ["--silent", "--raw"]
                 },
                 "desc function": {
-                    "query": "select routine_definition from information_schema.routines where concat(case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end) = '%s';",
-                    "options": ["-f", "--silent", "--raw", "--default-character-set=utf8"]
+                    "query": "select routine_definition from information_schema.routines where concat(case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end) = '{0}';",
+                    "options": ["--silent", "--raw"]
                 },
                 "explain plan": {
                     "query": "explain {0};",
-                    "options": ["-f", "--table", "--default-character-set=utf8"]
+                    "options": ["--table"]
                 }
             }
         },
@@ -196,6 +205,9 @@
             "args": "-d \"{database}\"",
             "args_optional": ["-S \"{host},{port}\"", "-S \"{host}\\{instance}\"", "-U \"{username}\"", "-P \"{password}\""],
             "queries": {
+                "exec": {
+                    "options": []
+                },
                 "desc": {
                     "query": "set nocount on; select concat(table_schema, '.', table_name) from information_schema.tables order by table_name;",
                     "options": ["-h", "-1"]
@@ -205,7 +217,7 @@
                     "options": ["-h", "-1"]
                 },
                 "desc table": {
-                    "query": "exec sp_help \"%s\";",
+                    "query": "exec sp_help \"{0}\";",
                     "options": []
                 },
                 "show records": {
@@ -220,6 +232,9 @@
             "after": [],
             "args": "-h {host} -p {port} -U \"{username}\" -w \"{password}\" -d \"{database}\"",
             "queries": {
+                "exec": {
+                    "options": []
+                },
                 "desc" : {
                     "query": "select '|' || table_schema || '.' || table_name || '|' as tblname from v_catalog.tables where is_system_table = false",
                     "options": ["--tuples-only", "--no-vsqlrc"]
@@ -229,7 +244,7 @@
                     "options": ["--tuples-only", "--no-vsqlrc"]
                 },
                 "desc table": {
-                    "query": "\\d %s",
+                    "query": "\\d {0}",
                     "options": []
                 },
                 "show records": {
@@ -244,10 +259,14 @@
         },
         "sqsh": {
             "options": [],
-            "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""],
+            "before": [],
             "after": [],
             "args": "-S {host}:{port} -U\"{username}\" -P\"{password}\" -D{database}",
             "queries": {
+                "exec": {
+                    "options": [],
+                    "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""]
+                },
                 "desc": {
                     "query": "select concat(table_schema, '.', table_name) from information_schema.tables order by table_name;",
                     "options": [],
@@ -259,29 +278,32 @@
                     "before" :["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""]
                 },
                 "desc table": {
-                    "query": "exec sp_columns \"%s\";",
+                    "query": "exec sp_columns \"{0}\";",
                     "options": [],
                     "before": ["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""]
                 },
                 "show records": {
                     "query": "select top {1} * from \"{0}\";",
                     "options": [],
-                    "before": ["\\set semicolon_cmd=\"\\go -mpretty -l -h -f\""]
+                    "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""]
                 }
             }
         },
         "sqlite": {
-            "options": ["-column", "-header"],
+            "options": [],
             "before": [],
             "after": [],
             "args": "\"{database}\"",
             "queries": {
+                "exec": {
+                    "options": ["-column", "-header"]
+                },
                 "desc" : {
                     "query": ".headers off\nSELECT '|' || name || '|' FROM sqlite_master WHERE type='table';",
                     "options": ["-noheader"]
                 },
                 "desc table": {
-                    "query": ".schema \"%s\"",
+                    "query": ".schema \"{0}\"",
                     "options": ["-column", "-header"]
                 },
                 "show records": {
@@ -300,16 +322,19 @@
             "after": [],
             "args": "-u \"{username}\" -p \"{password}\" \"{host}/{port}:{database}\"",
             "queries": {
+                "exec": {
+                    "options": []
+                },
                 "desc" : {
                     "query": "select '|' || rdb$relation_name || '|' from rdb$relations where rdb$view_blr is null and (rdb$system_flag is null or rdb$system_flag = 0);",
                     "options": []
                 },
                 "desc table": {
-                    "query": "show table \"%s\";",
+                    "query": "show table \"{0}\";",
                     "options": []
                 },
                 "show records": {
-                    "query": "select first 100 * from \"%s\";",
+                    "query": "select first {1} * from \"{0}\";",
                     "options": []
                 }
             }

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -169,7 +169,7 @@
                     ]
                 },
                 "desc" : {
-                    "query": "select owner || '.' || name as obj from (select owner, table_name as name from all_tables union all select owner, view_name as name from all_views) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "query": "select owner || '.' || case when UPPER(name) = name then name else chr(34) || name || chr(34) end as obj from (select owner, table_name as name from all_tables union all select owner, view_name as name from all_views) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
                     "options": [],
                     "before": [
                         "SET SERVEROUT  OFF",  // override
@@ -179,7 +179,7 @@
                     ]
                 },
                 "columns": {
-                    "query": "select table_name || '.' || column_name as obj from (select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_tables t on c.owner = t.owner and c.table_name = t.table_name union all select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_views t on c.owner = t.owner and c.table_name = t.view_name) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "query": "select case when UPPER(table_name) = table_name then table_name else chr(34) || table_name || chr(34) end || '.' || case when UPPER(column_name) = column_name then column_name else chr(34) || column_name || chr(34) end as obj from (select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_tables t on c.owner = t.owner and c.table_name = t.table_name union all select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_views t on c.owner = t.owner and c.table_name = t.view_name) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
                     "options": [],
                     "before": [
                         "SET SERVEROUT  OFF",  // override

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -74,7 +74,7 @@
                 "PGPASSWORD": "{password}"
             },
             "queries": {
-                "exec": {
+                "execute": {
                     "options": []
                 },
                 "desc": {
@@ -109,52 +109,123 @@
         },
         "oracle": {
             "options": ["-S"],
-            "before": [
-                "SET AUTO           OFF",
-                "SET COLSEP         '|'",
-                "SET FEED           ON",
-                "SET FEEDBACK       ON",
-                "SET HEADING        ON",
-                "SET LINESIZE       32767",
-                "SET LONG           100",
-                "SET NULL           @",
-                "SET PAGESIZE       0 EMBEDDED ON",
-                "SET SERVEROUTPUT   ON",
-                "SET SQLBLANKLINES  ON",
-                "SET SQLPROMPT      ''",
-                "SET TAB            OFF",
-                "SET TI             ON",
-                "SET TIMI           OFF",
-                "SET TRIMSPOOL      OFF",
-                "SET UND            '-'",
-                "SET VERIFY         OFF ",
-                "SET WRAP           OFF"
-            ],
+            "before": [],
             "after": [],
+            "env_optional": {
+                "NLS_LANG": "{nls_lang}"
+            },
             "args": "{username}/{password}@\"(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT={port})))(CONNECT_DATA=(SERVICE_NAME={service})))\"",
             "queries": {
-                "exec": {
-                    "options": []
+                "execute": {
+                    "options": [],
+                    "before": [
+                        // "SET TIMING     ON",
+                        "SET LINESIZE   32767",
+                        "SET PAGESIZE   0",
+                        "SET EMBEDDED   ON",
+                        "SET WRAP       OFF",
+                        "SET TAB        OFF",
+                        "SET TRIMOUT    ON",
+                        "SET TRIMSPOOL  ON",
+                        "SET NULL       '@'",
+                        "SET COLSEP     '|'",
+                        "SET FEEDBACK   ON",
+                        "SET SERVEROUT  ON",
+                        "SET SQLBLANKLINES ON"
+                    ]
                 },
                 "desc" : {
-                    "query": "select concat(concat(concat(concat('|', owner), '.'), table_name), '|') as tbls from all_tables UNION ALL select concat(concat(concat(concat('|', owner), '.'), view_name), '|') as tbls from all_views;",
-                    "options": []
+                    "query": "select owner || '.' || name as obj from (select owner, table_name as name from all_tables union all select owner, view_name as name from all_views) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "options": [],
+                    "before": [
+                        "SET LINESIZE  32767",
+                        "SET PAGESIZE  0",
+                        "SET EMBEDDED  ON",
+                        "SET WRAP      OFF",
+                        "SET HEADING   OFF",
+                        "SET FEEDBACK  OFF",
+                        "SET TRIMOUT   ON"
+                    ]
                 },
                 "columns": {
-                    "query": "SELECT concat(concat(concat(concat('|', c.table_name), '.'), c.column_name), '|') AS cols FROM all_tab_columns c INNER JOIN all_tables t ON c.owner = t.owner AND c.table_name = t.table_name UNION ALL SELECT concat(concat(concat(concat('|', c.table_name), '.'), c.column_name), '|') AS cols FROM all_tab_columns c INNER JOIN all_views t ON c.owner = t.owner AND c.table_name = t.view_name;",
-                    "options": []
+                    "query": "select table_name || '.' || column_name as obj from (select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_tables t on c.owner = t.owner and c.table_name = t.table_name union all select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_views t on c.owner = t.owner and c.table_name = t.view_name) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "options": [],
+                    "before": [
+                        "SET LINESIZE  32767",
+                        "SET PAGESIZE  0",
+                        "SET EMBEDDED  ON",
+                        "SET WRAP      OFF",
+                        "SET HEADING   OFF",
+                        "SET FEEDBACK  OFF",
+                        "SET TRIMOUT   ON"
+                    ]
+                },
+                "functions": {
+                    "query": "select case when object_type = 'PACKAGE' then object_name||'.'||procedure_name else owner || '.' || object_name end || '()' as obj from all_procedures where object_type in ('FUNCTION','PROCEDURE','PACKAGE') and owner = sys_context('USERENV', 'CURRENT_SCHEMA');",
+                    "options": [],
+                    "before": [
+                        "SET LINESIZE  32767",
+                        "SET PAGESIZE  0",
+                        "SET EMBEDDED  ON",
+                        "SET WRAP      OFF",
+                        "SET HEADING   OFF",
+                        "SET FEEDBACK  OFF",
+                        "SET TRIMOUT   ON"
+                    ]
                 },
                 "desc table": {
                     "query": "desc {0};",
-                    "options": []
+                    "options": [],
+                    "before": [
+                        "SET LINESIZE   80",  // altered for readability
+                        "SET PAGESIZE   0",
+                        "SET EMBEDDED   ON",
+                        "SET WRAP       OFF",
+                        "SET TAB        OFF",
+                        "SET TRIMOUT    ON",
+                        "SET TRIMSPOOL  ON",
+                        "SET NULL       '@'",
+                        "SET COLSEP     '|'",
+                        "SET FEEDBACK   ON",
+                        "SET SERVEROUT  ON",
+                        "SET SQLBLANKLINES ON"
+                    ]
                 },
                 "show records": {
                     "query": "select * from {0} WHERE ROWNUM <= {1};",
-                    "options": []
+                    "options": [],
+                    "before": [
+                        "SET LINESIZE   32767",
+                        "SET PAGESIZE   0",
+                        "SET EMBEDDED   ON",
+                        "SET WRAP       OFF",
+                        "SET TAB        OFF",
+                        "SET TRIMOUT    ON",
+                        "SET TRIMSPOOL  ON",
+                        "SET NULL       '@'",
+                        "SET COLSEP     '|'",
+                        "SET FEEDBACK   ON",
+                        "SET SERVEROUT  ON",
+                        "SET SQLBLANKLINES ON"
+                    ]
                 },
                 "explain plan": {
                     "query": "explain plan for {0};\nselect plan_table_output from table(dbms_xplan.display());",
-                    "options": []
+                    "options": [],
+                    "before": [
+                        "SET LINESIZE   32767",
+                        "SET PAGESIZE   0",
+                        "SET EMBEDDED   ON",
+                        "SET WRAP       OFF",
+                        "SET TAB        OFF",
+                        "SET TRIMOUT    ON",
+                        "SET TRIMSPOOL  ON",
+                        "SET NULL       '@'",
+                        "SET COLSEP     '|'",
+                        "SET FEEDBACK   ON",
+                        "SET SERVEROUT  ON",
+                        "SET SQLBLANKLINES ON"
+                    ]
                 }
             }
         },
@@ -165,7 +236,7 @@
             "args": "-h{host} -P{port} -u\"{username}\" -D\"{database}\"",
             "args_optional": ["--login-path=\"{login-path}\"", "--defaults-extra-file=\"{defaults-extra-file}\"", "-p\"{password}\""],
             "queries": {
-                "exec": {
+                "execute": {
                     "options": ["--table", "-f"]
                 },
                 "desc" : {
@@ -201,28 +272,45 @@
         "mssql": {
             "options": [],
             "before": [],
-            "after": ["GO", "QUIT"],
+            "after": ["go", "quit"],
             "args": "-d \"{database}\"",
             "args_optional": ["-S \"{host},{port}\"", "-S \"{host}\\{instance}\"", "-U \"{username}\"", "-P \"{password}\""],
             "queries": {
-                "exec": {
-                    "options": []
-                },
-                "desc": {
-                    "query": "set nocount on; select concat(table_schema, '.', table_name) from information_schema.tables order by table_name;",
-                    "options": ["-h", "-1"]
-                },
-                "columns": {
-                    "query": "set nocount on; select concat(table_name, '.', column_name) from information_schema.columns order by table_name, ordinal_position;",
-                    "options": ["-h", "-1"]
-                },
-                "desc table": {
-                    "query": "exec sp_help \"{0}\";",
-                    "options": []
+                "execute": {
+                    "options": ["-k"]
                 },
                 "show records": {
                     "query": "select top {1} * from {0};",
                     "options": []
+                },
+                "desc table": {
+                    "query": "exec sp_help N'{0}';",
+                    "options": ["-y30", "-Y30"]
+                },
+                "desc function": {
+                    "query": "exec sp_helptext N'{0}';",
+                    "options": ["-h-1"]
+                },
+                "desc": {
+                    "query": "set nocount on; select concat(table_schema, '.', table_name) as obj from information_schema.tables order by table_schema, table_name;",
+                    "options": ["-h-1"]
+                },
+                "columns": {
+                    "query": "set nocount on; select distinct concat(table_name, '.', column_name) as obj from information_schema.columns;",
+                    "options": ["-h-1"]
+                },
+                "functions": {
+                    "query": "set nocount on; select concat(routine_schema, '.', routine_name) as obj from information_schema.routines order by routine_schema, routine_name;",
+                    "options": ["-h-1"]
+                },
+                 "explain plan": {
+                    "query": "{0};",
+                    "options": ["-k"],
+                    "before": [
+                        "SET STATISTICS PROFILE ON",
+                        "SET STATISTICS IO ON",
+                        "SET STATISTICS TIME ON"
+                    ]
                 }
             }
         },
@@ -232,7 +320,7 @@
             "after": [],
             "args": "-h {host} -p {port} -U \"{username}\" -w \"{password}\" -d \"{database}\"",
             "queries": {
-                "exec": {
+                "execute": {
                     "options": []
                 },
                 "desc" : {
@@ -263,7 +351,7 @@
             "after": [],
             "args": "-S {host}:{port} -U\"{username}\" -P\"{password}\" -D{database}",
             "queries": {
-                "exec": {
+                "execute": {
                     "options": [],
                     "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""]
                 },
@@ -295,7 +383,7 @@
             "after": [],
             "args": "\"{database}\"",
             "queries": {
-                "exec": {
+                "execute": {
                     "options": ["-column", "-header"]
                 },
                 "desc" : {
@@ -322,7 +410,7 @@
             "after": [],
             "args": "-u \"{username}\" -p \"{password}\" \"{host}/{port}:{database}\"",
             "queries": {
-                "exec": {
+                "execute": {
                     "options": []
                 },
                 "desc" : {

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -94,16 +94,101 @@
                     "options": []
                 },
                 "desc": {
-                    "query": "select '|' || quote_ident(table_schema)||'.'||quote_ident(table_name) ||'|' as tblname from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema') order by table_schema = current_schema() desc, table_schema, table_name;",
+                    "query": "select quote_ident(table_schema) || '.' || quote_ident(table_name) as tblname from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema') order by table_schema = current_schema() desc, table_schema, table_name;",
                     "options": ["--tuples-only", "--no-psqlrc"]
                 },
                 "columns": {
-                    "query": "select '|' || quote_ident(table_name) || '.' || quote_ident(column_name) || '|' from information_schema.columns where table_schema not in ('pg_catalog', 'information_schema') order by table_name, ordinal_position;",
+                    "query": "select distinct quote_ident(table_name) || '.' || quote_ident(column_name) from information_schema.columns where table_schema not in ('pg_catalog', 'information_schema');",
                     "options": ["--tuples-only", "--no-psqlrc"]
                 },
                 "functions": {
-                    "query": "select '|' || quote_ident(n.nspname)||'.'||quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' as funname from pg_catalog.pg_proc as f inner join pg_catalog.pg_namespace as n on n.oid = f.pronamespace where f.proisagg = false and n.nspname not in ('pg_catalog', 'information_schema');",
+                    "query": "select quote_ident(n.nspname) || '.' || quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' as funname from pg_catalog.pg_proc as f inner join pg_catalog.pg_namespace as n on n.oid = f.pronamespace where f.proisagg = false and n.nspname not in ('pg_catalog', 'information_schema');",
                     "options": ["--tuples-only", "--no-psqlrc"]
+                }
+            }
+        },
+        "mysql": {
+            "options": ["--default-character-set=utf8"],
+            "before": [],
+            "after": [],
+            "args": "-h{host} -P{port} -u\"{username}\" -D\"{database}\"",
+            "args_optional": ["--login-path=\"{login-path}\"", "--defaults-extra-file=\"{defaults-extra-file}\"", "-p\"{password}\""],
+            "queries": {
+                "execute": {
+                    "options": ["--table", "-f"]
+                },
+                "show records": {
+                    "query": "select * from {0} limit {1};",
+                    "options": ["--table"]
+                },
+                "desc table": {
+                    "query": "desc {0}",
+                    "options": ["--table"]
+                },
+                "desc function": {
+                    "query": "select routine_definition from information_schema.routines where concat(case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end) = '{0}';",
+                    "options": ["--silent", "--raw"]
+                },
+                "explain plan": {
+                    "query": "explain {0};",
+                    "options": ["--table"]
+                },
+                "desc" : {
+                    "query": "select concat(case when table_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_schema,'`') else table_schema end, '.', case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end) as obj from information_schema.tables where table_schema = database() order by table_name;",
+                    "options": ["--silent", "--raw"]
+                },
+                "columns": {
+                    "query": "select concat(case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end, '.', case when column_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',column_name,'`') else column_name end) as obj from information_schema.columns where table_schema = database() order by table_name, ordinal_position;",
+                    "options": ["--silent", "--raw"]
+                },
+                "functions": {
+                    "query": "select concat(case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end, '()') as obj from information_schema.routines where routine_schema = database();",
+                    "options": ["--silent", "--raw"]
+                }
+            }
+        },
+        "mssql": {
+            "options": [],
+            "before": [],
+            "after": ["go", "quit"],
+            "args": "-d \"{database}\"",
+            "args_optional": ["-S \"{host},{port}\"", "-S \"{host}\\{instance}\"", "-U \"{username}\"", "-P \"{password}\""],
+            "queries": {
+                "execute": {
+                    "options": ["-k"]
+                },
+                "show records": {
+                    "query": "select top {1} * from {0};",
+                    "options": []
+                },
+                "desc table": {
+                    "query": "exec sp_help N'{0}';",
+                    "options": ["-y30", "-Y30"]
+                },
+                "desc function": {
+                    "query": "exec sp_helptext N'{0}';",
+                    "options": ["-h-1"]
+                },
+                "explain plan": {
+                    "query": "{0};",
+                    "options": ["-k"],
+                    "before": [
+                        "SET STATISTICS PROFILE ON",
+                        "SET STATISTICS IO ON",
+                        "SET STATISTICS TIME ON"
+                    ]
+                },
+                "desc": {
+                    "query": "set nocount on; select concat(table_schema, '.', table_name) as obj from information_schema.tables order by table_schema, table_name;",
+                    "options": ["-h-1"]
+                },
+                "columns": {
+                    "query": "set nocount on; select distinct concat(table_name, '.', column_name) as obj from information_schema.columns;",
+                    "options": ["-h-1"]
+                },
+                "functions": {
+                    "query": "set nocount on; select concat(routine_schema, '.', routine_name) as obj from information_schema.routines order by routine_schema, routine_name;",
+                    "options": ["-h-1"]
                 }
             }
         },
@@ -151,13 +236,6 @@
                         "SET FEEDBACK   ON"
                     ]
                 },
-                "explain plan": {
-                    "query": "explain plan for {0};\nselect plan_table_output from table(dbms_xplan.display());",
-                    "options": [],
-                    "before": [
-                        "SET FEEDBACK   ON"
-                    ]
-                },
                 "desc function": {
                     "query": "select text from all_source where type in ('FUNCTION', 'PROCEDURE', 'PACKAGE', 'PACKAGE BODY') and name = nvl(substr(ltrim('{0}', sys_context('USERENV', 'CURRENT_SCHEMA') || '.' ), 0, instr(ltrim('{0}', sys_context('USERENV', 'CURRENT_SCHEMA') || '.' ), '.')-1), ltrim('{0}', sys_context('USERENV', 'CURRENT_SCHEMA') || '.' )) and owner = sys_context('USERENV', 'CURRENT_SCHEMA') order by type, line;",
                     "options": [],
@@ -168,8 +246,15 @@
                         "SET FEEDBACK   OFF"
                     ]
                 },
+                "explain plan": {
+                    "query": "explain plan for {0};\nselect plan_table_output from table(dbms_xplan.display());",
+                    "options": [],
+                    "before": [
+                        "SET FEEDBACK   ON"
+                    ]
+                },
                 "desc" : {
-                    "query": "select owner || '.' || case when UPPER(name) = name then name else chr(34) || name || chr(34) end as obj from (select owner, table_name as name from all_tables union all select owner, view_name as name from all_views) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "query": "select owner || '.' || case when upper(name) = name then name else chr(34) || name || chr(34) end as obj from (select owner, table_name as name from all_tables union all select owner, view_name as name from all_views) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
                     "options": [],
                     "before": [
                         "SET SERVEROUT  OFF",  // override
@@ -179,7 +264,7 @@
                     ]
                 },
                 "columns": {
-                    "query": "select case when UPPER(table_name) = table_name then table_name else chr(34) || table_name || chr(34) end || '.' || case when UPPER(column_name) = column_name then column_name else chr(34) || column_name || chr(34) end as obj from (select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_tables t on c.owner = t.owner and c.table_name = t.table_name union all select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_views t on c.owner = t.owner and c.table_name = t.view_name) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "query": "select case when upper(table_name) = table_name then table_name else chr(34) || table_name || chr(34) end || '.' || case when upper(column_name) = column_name then column_name else chr(34) || column_name || chr(34) end as obj from (select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_tables t on c.owner = t.owner and c.table_name = t.table_name union all select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_views t on c.owner = t.owner and c.table_name = t.view_name) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
                     "options": [],
                     "before": [
                         "SET SERVEROUT  OFF",  // override
@@ -200,87 +285,32 @@
                 }
             }
         },
-        "mysql": {
-            "options": ["--default-character-set=utf8"],
-            "before": [],
-            "after": [],
-            "args": "-h{host} -P{port} -u\"{username}\" -D\"{database}\"",
-            "args_optional": ["--login-path=\"{login-path}\"", "--defaults-extra-file=\"{defaults-extra-file}\"", "-p\"{password}\""],
-            "queries": {
-                "execute": {
-                    "options": ["--table", "-f"]
-                },
-                "desc" : {
-                    "query": "select concat('|', case when table_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_schema,'`') else table_schema end, '.', case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end, '|') from information_schema.tables where table_schema = database() order by table_name;",
-                    "options": ["--silent", "--raw"]
-                },
-                "desc table": {
-                    "query": "desc {0}",
-                    "options": ["--table"]
-                },
-                "show records": {
-                    "query": "select * from {0} limit {1}",
-                    "options": ["--table"]
-                },
-                "columns": {
-                    "query": "select concat('|',  case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end, '.', case when column_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',column_name,'`') else column_name end, '|') from information_schema.columns where table_schema = database() order by table_name, ordinal_position;",
-                    "options": ["--silent", "--raw"]
-                },
-                "functions": {
-                    "query": "select concat('|', case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end, '()', '|') from information_schema.routines where routine_schema = database();",
-                    "options": ["--silent", "--raw"]
-                },
-                "desc function": {
-                    "query": "select routine_definition from information_schema.routines where concat(case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end) = '{0}';",
-                    "options": ["--silent", "--raw"]
-                },
-                "explain plan": {
-                    "query": "explain {0};",
-                    "options": ["--table"]
-                }
-            }
-        },
-        "mssql": {
+        "sqlite": {
             "options": [],
             "before": [],
-            "after": ["go", "quit"],
-            "args": "-d \"{database}\"",
-            "args_optional": ["-S \"{host},{port}\"", "-S \"{host}\\{instance}\"", "-U \"{username}\"", "-P \"{password}\""],
+            "after": [],
+            "args": "\"{database}\"",
             "queries": {
                 "execute": {
-                    "options": ["-k"]
+                    "options": ["-column", "-header", "-bail"]
                 },
                 "show records": {
-                    "query": "select top {1} * from {0};",
-                    "options": []
+                    "query": "select * from \"{0}\" limit {1};",
+                    "options": ["-column", "-header"]
+                },
+                "explain plan": {
+                    "query": "EXPLAIN QUERY PLAN {0};",
+                    "options": ["-column", "-header", "-bail"]
                 },
                 "desc table": {
-                    "query": "exec sp_help N'{0}';",
-                    "options": ["-y30", "-Y30"]
+                    "query": ".schema \"{0}\"",
+                    "options": ["-column", "-header"]
                 },
-                "desc function": {
-                    "query": "exec sp_helptext N'{0}';",
-                    "options": ["-h-1"]
-                },
-                "desc": {
-                    "query": "set nocount on; select concat(table_schema, '.', table_name) as obj from information_schema.tables order by table_schema, table_name;",
-                    "options": ["-h-1"]
-                },
-                "columns": {
-                    "query": "set nocount on; select distinct concat(table_name, '.', column_name) as obj from information_schema.columns;",
-                    "options": ["-h-1"]
-                },
-                "functions": {
-                    "query": "set nocount on; select concat(routine_schema, '.', routine_name) as obj from information_schema.routines order by routine_schema, routine_name;",
-                    "options": ["-h-1"]
-                },
-                 "explain plan": {
-                    "query": "{0};",
-                    "options": ["-k"],
+                "desc" : {
+                    "query": "SELECT name FROM sqlite_master WHERE type='table';",
+                    "options": ["-noheader"],
                     "before": [
-                        "SET STATISTICS PROFILE ON",
-                        "SET STATISTICS IO ON",
-                        "SET STATISTICS TIME ON"
+                        ".headers off"
                     ]
                 }
             }
@@ -294,25 +324,96 @@
                 "execute": {
                     "options": []
                 },
-                "desc" : {
-                    "query": "select '|' || table_schema || '.' || table_name || '|' as tblname from v_catalog.tables where is_system_table = false",
-                    "options": ["--tuples-only", "--no-vsqlrc"]
-                },
-                "columns": {
-                    "query": "select '|' || table_name || '.' || column_name || '|' as tblname from v_catalog.columns where is_system_table = false order by table_name, ordinal_position",
-                    "options": ["--tuples-only", "--no-vsqlrc"]
+                "show records": {
+                    "query": "select * from {0} limit {1};",
+                    "options": []
                 },
                 "desc table": {
                     "query": "\\d {0}",
                     "options": []
                 },
-                "show records": {
-                    "query": "select * from {0} limit {1}",
-                    "options": []
-                },
                 "explain plan": {
                     "query": "explain {0};",
                     "options": []
+                },
+                "desc" : {
+                    "query": "select table_schema || '.' || table_name as tblname from v_catalog.tables where is_system_table = false;",
+                    "options": ["--tuples-only", "--no-vsqlrc"]
+                },
+                "columns": {
+                    "query": "select table_name || '.' || column_name as tblname from v_catalog.columns where is_system_table = false order by table_name, ordinal_position;",
+                    "options": ["--tuples-only", "--no-vsqlrc"]
+                }
+            }
+        },
+        "firebird": {
+            "options": [],
+            "before": [],
+            "after": [],
+            "args": "-pagelength 10000 -u \"{username}\" -p \"{password}\" \"{host}/{port}:{database}\"",
+            "queries": {
+                "execute": {
+                    "options": [],
+                    "before": [
+                        "set bail on;",
+                        "set count on;"
+                    ]
+                },
+                "show records": {
+                    "query": "select first {1} * from {0};",
+                    "options": [],
+                    "before": [
+                        "set bail off;",
+                        "set count on;"
+                    ]
+                },
+                "desc table": {
+                    "query": "show table {0}; \n show view {0};",
+                    "before": [
+                        "set bail off;"
+                    ]
+                },
+                "desc function": {
+                    "query": "show procedure {0};",
+                    "before": [
+                        "set bail off;"
+                    ]
+                },
+                "explain plan": {
+                    "query": "{0};",
+                    "before": [
+                        "set bail on;",
+                        "set count on;",
+                        "set plan on;",
+                        "set stats on;"
+                    ]
+                },
+                "desc" : {
+                    "query": "select case when upper(rdb$relation_name) = rdb$relation_name then trim(rdb$relation_name) else '\"' || trim(rdb$relation_name) || '\"' end as obj from rdb$relations where (rdb$system_flag is null or rdb$system_flag = 0);",
+                    "before": [
+                        "set bail off;",
+                        "set heading off;",
+                        "set count off;",
+                        "set stats off;"
+                    ]
+                },
+                "columns": {
+                    "query": "select case when upper(f.rdb$relation_name) = f.rdb$relation_name then trim(f.rdb$relation_name) else '\"' || trim(f.rdb$relation_name) || '\"' end || '.' || case when upper(f.rdb$field_name) = f.rdb$field_name then trim(f.rdb$field_name) else '\"' || trim(f.rdb$field_name) || '\"' end as obj from rdb$relation_fields f join rdb$relations r on f.rdb$relation_name = r.rdb$relation_name where (r.rdb$system_flag is null or r.rdb$system_flag = 0) order by f.rdb$relation_name, f.rdb$field_position;",
+                    "before": [
+                        "set bail off;",
+                        "set heading off;",
+                        "set count off;",
+                        "set stats off;"
+                    ]
+                },
+                "functions": {
+                    "query": "select case when upper(rdb$procedure_name) = rdb$procedure_name then trim(rdb$procedure_name) else '\"' || trim(rdb$procedure_name) || '\"' end || '()' as obj from rdb$procedures where (rdb$system_flag is null or rdb$system_flag = 0);",
+                    "before": [
+                        "set bail off;",
+                        "set heading off;",
+                        "set count off;",
+                        "set stats off;"
+                    ]
                 }
             }
         },
@@ -345,56 +446,6 @@
                     "query": "select top {1} * from \"{0}\";",
                     "options": [],
                     "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""]
-                }
-            }
-        },
-        "sqlite": {
-            "options": [],
-            "before": [],
-            "after": [],
-            "args": "\"{database}\"",
-            "queries": {
-                "execute": {
-                    "options": ["-column", "-header"]
-                },
-                "desc" : {
-                    "query": ".headers off\nSELECT '|' || name || '|' FROM sqlite_master WHERE type='table';",
-                    "options": ["-noheader"]
-                },
-                "desc table": {
-                    "query": ".schema \"{0}\"",
-                    "options": ["-column", "-header"]
-                },
-                "show records": {
-                    "query": "select * from \"{0}\" limit {1};",
-                    "options": ["-column", "-header"]
-                },
-                "explain plan": {
-                    "query": "EXPLAIN QUERY PLAN {0};",
-                    "options": ["-column", "-header"]
-                }
-            }
-        },
-        "firebird": {
-            "options": [],
-            "before": [],
-            "after": [],
-            "args": "-u \"{username}\" -p \"{password}\" \"{host}/{port}:{database}\"",
-            "queries": {
-                "execute": {
-                    "options": []
-                },
-                "desc" : {
-                    "query": "select '|' || rdb$relation_name || '|' from rdb$relations where rdb$view_blr is null and (rdb$system_flag is null or rdb$system_flag = 0);",
-                    "options": []
-                },
-                "desc table": {
-                    "query": "show table \"{0}\";",
-                    "options": []
-                },
-                "show records": {
-                    "query": "select first {1} * from \"{0}\";",
-                    "options": []
                 }
             }
         }

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -77,39 +77,51 @@
                 "execute": {
                     "options": []
                 },
-                "desc": {
-                    "query": "select '|' || quote_ident(table_schema)||'.'||quote_ident(table_name) ||'|' as tblname from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema') order by table_schema = current_schema() desc, table_schema, table_name",
-                    "options": ["--tuples-only", "--no-psqlrc"]
+                "show records": {
+                    "query": "select * from {0} limit {1};",
+                    "options": []
                 },
                 "desc table": {
                     "query": "\\d+ {0}",
                     "options": []
-                },
-                "show records": {
-                    "query": "select * from {0} limit {1}",
-                    "options": []
-                },
-                "columns": {
-                    "query": "select '|' || quote_ident(table_name) || '.' || quote_ident(column_name) || '|' from information_schema.columns where table_schema not in ('pg_catalog', 'information_schema') order by table_name, ordinal_position",
-                    "options": ["--tuples-only", "--no-psqlrc"]
-                },
-                "functions": {
-                    "query": "select '|' || quote_ident(n.nspname)||'.'||quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' as funname from pg_catalog.pg_proc as f inner join pg_catalog.pg_namespace as n on n.oid = f.pronamespace where f.proisagg = false and n.nspname not in ('pg_catalog', 'information_schema')",
-                    "options": ["--tuples-only", "--no-psqlrc"]
                 },
                 "desc function": {
                     "query": "\\sf {0}",
                     "options": []
                 },
                 "explain plan": {
-                    "query": "explain {0};",
+                    "query": "explain analyze {0};",
                     "options": []
+                },
+                "desc": {
+                    "query": "select '|' || quote_ident(table_schema)||'.'||quote_ident(table_name) ||'|' as tblname from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema') order by table_schema = current_schema() desc, table_schema, table_name;",
+                    "options": ["--tuples-only", "--no-psqlrc"]
+                },
+                "columns": {
+                    "query": "select '|' || quote_ident(table_name) || '.' || quote_ident(column_name) || '|' from information_schema.columns where table_schema not in ('pg_catalog', 'information_schema') order by table_name, ordinal_position;",
+                    "options": ["--tuples-only", "--no-psqlrc"]
+                },
+                "functions": {
+                    "query": "select '|' || quote_ident(n.nspname)||'.'||quote_ident(f.proname) || '(' || pg_get_function_identity_arguments(f.oid) || ')' || '|' as funname from pg_catalog.pg_proc as f inner join pg_catalog.pg_namespace as n on n.oid = f.pronamespace where f.proisagg = false and n.nspname not in ('pg_catalog', 'information_schema');",
+                    "options": ["--tuples-only", "--no-psqlrc"]
                 }
             }
         },
         "oracle": {
             "options": ["-S"],
-            "before": [],
+            "before": [
+                "SET LINESIZE   32767",
+                "SET WRAP       OFF",
+                "SET PAGESIZE   0",
+                "SET EMBEDDED   ON",
+                "SET TRIMOUT    ON",
+                "SET TRIMSPOOL  ON",
+                "SET TAB        OFF",
+                "SET SERVEROUT  ON",
+                "SET NULL       '@'",
+                "SET COLSEP     '|'",
+                "SET SQLBLANKLINES ON"
+            ],
             "after": [],
             "env_optional": {
                 "NLS_LANG": "{nls_lang}"
@@ -120,111 +132,70 @@
                     "options": [],
                     "before": [
                         // "SET TIMING     ON",
-                        "SET LINESIZE   32767",
-                        "SET PAGESIZE   0",
-                        "SET EMBEDDED   ON",
-                        "SET WRAP       OFF",
-                        "SET TAB        OFF",
-                        "SET TRIMOUT    ON",
-                        "SET TRIMSPOOL  ON",
-                        "SET NULL       '@'",
-                        "SET COLSEP     '|'",
-                        "SET FEEDBACK   ON",
-                        "SET SERVEROUT  ON",
-                        "SET SQLBLANKLINES ON"
+                        "SET FEEDBACK   ON"
                     ]
                 },
-                "desc" : {
-                    "query": "select owner || '.' || name as obj from (select owner, table_name as name from all_tables union all select owner, view_name as name from all_views) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                "show records": {
+                    "query": "select * from {0} where rownum <= {1};",
                     "options": [],
                     "before": [
-                        "SET LINESIZE  32767",
-                        "SET PAGESIZE  0",
-                        "SET EMBEDDED  ON",
-                        "SET WRAP      OFF",
-                        "SET HEADING   OFF",
-                        "SET FEEDBACK  OFF",
-                        "SET TRIMOUT   ON"
-                    ]
-                },
-                "columns": {
-                    "query": "select table_name || '.' || column_name as obj from (select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_tables t on c.owner = t.owner and c.table_name = t.table_name union all select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_views t on c.owner = t.owner and c.table_name = t.view_name) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
-                    "options": [],
-                    "before": [
-                        "SET LINESIZE  32767",
-                        "SET PAGESIZE  0",
-                        "SET EMBEDDED  ON",
-                        "SET WRAP      OFF",
-                        "SET HEADING   OFF",
-                        "SET FEEDBACK  OFF",
-                        "SET TRIMOUT   ON"
-                    ]
-                },
-                "functions": {
-                    "query": "select case when object_type = 'PACKAGE' then object_name||'.'||procedure_name else owner || '.' || object_name end || '()' as obj from all_procedures where object_type in ('FUNCTION','PROCEDURE','PACKAGE') and owner = sys_context('USERENV', 'CURRENT_SCHEMA');",
-                    "options": [],
-                    "before": [
-                        "SET LINESIZE  32767",
-                        "SET PAGESIZE  0",
-                        "SET EMBEDDED  ON",
-                        "SET WRAP      OFF",
-                        "SET HEADING   OFF",
-                        "SET FEEDBACK  OFF",
-                        "SET TRIMOUT   ON"
+                        "SET FEEDBACK   ON"
                     ]
                 },
                 "desc table": {
                     "query": "desc {0};",
                     "options": [],
                     "before": [
-                        "SET LINESIZE   80",  // altered for readability
-                        "SET PAGESIZE   0",
-                        "SET EMBEDDED   ON",
-                        "SET WRAP       OFF",
-                        "SET TAB        OFF",
-                        "SET TRIMOUT    ON",
-                        "SET TRIMSPOOL  ON",
-                        "SET NULL       '@'",
-                        "SET COLSEP     '|'",
-                        "SET FEEDBACK   ON",
-                        "SET SERVEROUT  ON",
-                        "SET SQLBLANKLINES ON"
-                    ]
-                },
-                "show records": {
-                    "query": "select * from {0} WHERE ROWNUM <= {1};",
-                    "options": [],
-                    "before": [
-                        "SET LINESIZE   32767",
-                        "SET PAGESIZE   0",
-                        "SET EMBEDDED   ON",
-                        "SET WRAP       OFF",
-                        "SET TAB        OFF",
-                        "SET TRIMOUT    ON",
-                        "SET TRIMSPOOL  ON",
-                        "SET NULL       '@'",
-                        "SET COLSEP     '|'",
-                        "SET FEEDBACK   ON",
-                        "SET SERVEROUT  ON",
-                        "SET SQLBLANKLINES ON"
+                        "SET LINESIZE   80",  // override for readability
+                        "SET WRAP       ON",  // override for readability
+                        "SET FEEDBACK   ON"
                     ]
                 },
                 "explain plan": {
                     "query": "explain plan for {0};\nselect plan_table_output from table(dbms_xplan.display());",
                     "options": [],
                     "before": [
-                        "SET LINESIZE   32767",
-                        "SET PAGESIZE   0",
-                        "SET EMBEDDED   ON",
-                        "SET WRAP       OFF",
-                        "SET TAB        OFF",
-                        "SET TRIMOUT    ON",
-                        "SET TRIMSPOOL  ON",
-                        "SET NULL       '@'",
-                        "SET COLSEP     '|'",
-                        "SET FEEDBACK   ON",
-                        "SET SERVEROUT  ON",
-                        "SET SQLBLANKLINES ON"
+                        "SET FEEDBACK   ON"
+                    ]
+                },
+                "desc function": {
+                    "query": "select text from all_source where type in ('FUNCTION', 'PROCEDURE', 'PACKAGE', 'PACKAGE BODY') and name = nvl(substr(ltrim('{0}', sys_context('USERENV', 'CURRENT_SCHEMA') || '.' ), 0, instr(ltrim('{0}', sys_context('USERENV', 'CURRENT_SCHEMA') || '.' ), '.')-1), ltrim('{0}', sys_context('USERENV', 'CURRENT_SCHEMA') || '.' )) and owner = sys_context('USERENV', 'CURRENT_SCHEMA') order by type, line;",
+                    "options": [],
+                    "before": [
+                        "SET SERVEROUT  OFF",  // override
+                        "SET NULL       ''",   // override
+                        "SET HEADING    OFF",
+                        "SET FEEDBACK   OFF"
+                    ]
+                },
+                "desc" : {
+                    "query": "select owner || '.' || name as obj from (select owner, table_name as name from all_tables union all select owner, view_name as name from all_views) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "options": [],
+                    "before": [
+                        "SET SERVEROUT  OFF",  // override
+                        "SET NULL       ''",   // override
+                        "SET HEADING    OFF",
+                        "SET FEEDBACK   OFF"
+                    ]
+                },
+                "columns": {
+                    "query": "select table_name || '.' || column_name as obj from (select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_tables t on c.owner = t.owner and c.table_name = t.table_name union all select c.table_name, c.column_name, t.owner from all_tab_columns c inner join all_views t on c.owner = t.owner and c.table_name = t.view_name) o where owner not in ('ANONYMOUS','APPQOSSYS','CTXSYS','DBSNMP','EXFSYS', 'LBACSYS', 'MDSYS','MGMT_VIEW','OLAPSYS','OWBSYS','ORDPLUGINS', 'ORDSYS','OUTLN', 'SI_INFORMTN_SCHEMA','SYS','SYSMAN','SYSTEM', 'TSMSYS','WK_TEST','WKSYS', 'WKPROXY','WMSYS','XDB','APEX_040000', 'APEX_PUBLIC_USER','DIP', 'FLOWS_30000','FLOWS_FILES','MDDATA', 'ORACLE_OCM','SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL','PUBLIC');",
+                    "options": [],
+                    "before": [
+                        "SET SERVEROUT  OFF",  // override
+                        "SET NULL       ''",   // override
+                        "SET HEADING    OFF",
+                        "SET FEEDBACK   OFF"
+                    ]
+                },
+                "functions": {
+                    "query": "select case when object_type = 'PACKAGE' then object_name||'.'||procedure_name else owner || '.' || object_name end || '()' as obj from all_procedures where object_type in ('FUNCTION','PROCEDURE','PACKAGE') and not (object_type = 'PACKAGE' and procedure_name is null) and owner = sys_context('USERENV', 'CURRENT_SCHEMA');",
+                    "options": [],
+                    "before": [
+                        "SET SERVEROUT  OFF",  // override
+                        "SET NULL       ''",   // override
+                        "SET HEADING    OFF",
+                        "SET FEEDBACK   OFF"
                     ]
                 }
             }

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -71,92 +71,87 @@ You might need to restart the editor for settings to be refreshed."""
         return 'DB: {0}, Connection: {1}@{2}:{3}'.format(
             self.database, self.username, self.host, self.port)
 
-    def getTables(self, callback):
-        query = self.getOptionsForSgdbCli()['queries']['desc']['query']
+    def runInternalNamedQueryCommand(self, queryName, callback):
+        query = self.getNamedQuery(queryName)
+        if not query:
+            return
+
+        args = self.buildArgs(queryName)
+        env = self.buildEnv()
 
         def cb(result):
             callback(U.getResultAsList(result))
 
-        args = self.buildArgs('desc')
-        env = self.buildEnv()
         self.Command.createAndRun(args, env,
-                                  query, cb, silenceErrors=True)
+                                  query, cb,
+                                  silenceErrors=True)
+
+    def getTables(self, callback):
+        self.runInternalNamedQueryCommand('desc', callback)
 
     def getColumns(self, callback):
-
-        def cb(result):
-            callback(U.getResultAsList(result))
-
-        try:
-            query = self.getOptionsForSgdbCli()['queries']['columns']['query']
-            args = self.buildArgs('columns')
-            env = self.buildEnv()
-            self.Command.createAndRun(args, env,
-                                      query, cb, silenceErrors=True)
-        except Exception:
-            pass
+        self.runInternalNamedQueryCommand('columns', callback)
 
     def getFunctions(self, callback):
+        self.runInternalNamedQueryCommand('functions', callback)
 
-        def cb(result):
-            callback(U.getResultAsList(result))
+    def runFormattedNamedQueryCommand(self, queryName, formatValues, callback):
+        query = self.getNamedQuery(queryName)
+        if not query:
+            return
 
-        try:
-            query = self.getOptionsForSgdbCli()['queries']['functions']['query']
-            args = self.buildArgs('functions')
-            env = self.buildEnv()
-            self.Command.createAndRun(args, env,
-                                      query, cb, silenceErrors=True)
-        except Exception:
-            pass
+        # added for compatibility with older format string
+        query = query.replace("%s", "{0}", 1)
+        query = query.replace("%s", "{1}", 1)
 
-    def getTableRecords(self, tableName, callback):
-        query = self.getOptionsForSgdbCli()['queries']['show records']['query'].format(tableName, self.rowsLimit)
-        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
-        args = self.buildArgs('show records')
+        if isinstance(formatValues, tuple):
+            query = query.format(*formatValues)  # unpack the tuple
+        else:
+            query = query.format(formatValues)
+
+        queryToRun = self.buildNamedQuery(queryName, query)
+        args = self.buildArgs(queryName)
         env = self.buildEnv()
         self.Command.createAndRun(args, env, queryToRun, callback, timeout=self.timeout)
 
+    def getTableRecords(self, tableName, callback):
+        # in case we expect multiple values pack them into tuple
+        formatValues = (tableName, self.rowsLimit)
+        self.runFormattedNamedQueryCommand('show records', formatValues, callback)
+
     def getTableDescription(self, tableName, callback):
-        query = self.getOptionsForSgdbCli()['queries']['desc table']['query'] % tableName
-        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
-        args = self.buildArgs('desc table')
-        env = self.buildEnv()
-        self.Command.createAndRun(args, env, queryToRun, callback)
+        self.runFormattedNamedQueryCommand('desc table', tableName, callback)
 
     def getFunctionDescription(self, functionName, callback):
-        query = self.getOptionsForSgdbCli()['queries']['desc function'][
-            'query'] % functionName
-        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + [query])
-        args = self.buildArgs('desc function')
-        env = self.buildEnv()
-        self.Command.createAndRun(args, env, queryToRun, callback)
+        self.runFormattedNamedQueryCommand('desc function', functionName, callback)
 
     def explainPlan(self, queries, callback):
-        try:
-            queryFormat = self.getOptionsForSgdbCli()['queries']['explain plan']['query']
-        except KeyError:
-            return  # do nothing, if DBMS has no support for explain plan
+        queryName = 'explain plan'
+        explainQuery = self.getNamedQuery(queryName)
+        if not explainQuery:
+            return
 
-        stripped_queries = [
-            queryFormat.format(query.strip().strip(";"))
+        strippedQueries = [
+            explainQuery.format(query.strip().strip(";"))
             for rawQuery in queries
             for query in filter(None, sqlparse.split(rawQuery))
         ]
-        queryToRun = '\n'.join(self.getOptionsForSgdbCli()['before'] + stripped_queries)
-        args = self.buildArgs('explain plan')
+        queryToRun = self.buildNamedQuery(queryName, strippedQueries)
+        args = self.buildArgs(queryName)
         env = self.buildEnv()
         self.Command.createAndRun(args, env, queryToRun, callback, timeout=self.timeout)
 
     def execute(self, queries, callback, stream=False):
-        queryToRun = ''
-
-        for query in self.getOptionsForSgdbCli()['before']:
-            queryToRun += query + "\n"
+        queryName = 'execute'
 
         if isinstance(queries, str):
             queries = [queries]
 
+        # add original (umodified) queries to the history
+        if self.history:
+            self.history.add('\n'.join(queries))
+
+        processedQueriesList = []
         for rawQuery in queries:
             for query in sqlparse.split(rawQuery):
                 if self.safe_limit:
@@ -172,16 +167,58 @@ You might need to restart the editor for settings to be refreshed."""
                             if (query.strip()[-1:] == ';'):
                                 query = query.strip()[:-1]
                             query += " LIMIT {0};".format(self.safe_limit)
-                queryToRun += query + "\n"
+                processedQueriesList.append(query)
+
+        queryToRun = self.buildNamedQuery(queryName, processedQueriesList)
+        args = self.buildArgs(queryName)
+        env = self.buildEnv()
 
         Log("Query: " + queryToRun)
 
-        if self.history:
-            self.history.add(queryToRun)
+        self.Command.createAndRun(args, env, queryToRun, callback,
+                                  options={'show_query': self.show_query},
+                                  timeout=self.timeout,
+                                  stream=stream)
 
-        args = self.buildArgs()
-        env = self.buildEnv()
-        self.Command.createAndRun(args, env, queryToRun, callback, options={'show_query': self.show_query}, timeout=self.timeout, stream=stream)
+    def getNamedQuery(self, queryName):
+        if not queryName:
+            return None
+
+        cliOptions = self.getOptionsForSgdbCli()
+        return cliOptions.get('queries', {}).get(queryName, {}).get('query')
+
+    def buildNamedQuery(self, queryName, queries):
+        if not queryName:
+            return None
+
+        if not queries:
+            return None
+
+        cliOptions = self.getOptionsForSgdbCli()
+        beforeCli = cliOptions.get('before')
+        beforeQuery = cliOptions.get('queries', {}).get(queryName, {}).get('before')
+        afterCli = cliOptions.get('after')
+        afterQuery = cliOptions.get('queries', {}).get(queryName, {}).get('after')
+
+        # sometimes we preprocess the raw queries from user, in that case we already have a list
+        if type(queries) is not list:
+            queries = [queries]
+
+        builtQueries = []
+        if beforeCli is not None:
+            builtQueries.extend(beforeCli)
+        if beforeQuery is not None:
+            builtQueries.extend(beforeQuery)
+        if queries is not None:
+            builtQueries.extend(queries)
+        if afterCli is not None:
+            builtQueries.extend(afterCli)
+        if afterQuery is not None:
+            builtQueries.extend(afterQuery)
+
+        print(builtQueries)
+
+        return '\n'.join(builtQueries)
 
     def buildArgs(self, queryName=None):
         cliOptions = self.getOptionsForSgdbCli()
@@ -200,11 +237,24 @@ You might need to restart the editor for settings to be refreshed."""
                 if formattedItem:
                     args = args + shlex.split(formattedItem)
 
+        # append generic options
+        # options = cliOptions.get('options', None)
+        # if options:
+        #     args = args + options
+
+        # append query specific options (if present)
+        # if queryName:
+        #     queryOptions = cliOptions.get('queries', {}).get(queryName, {}).get.('options')
+        #     if queryOptions:
+        #         if len(queryOptions) > 0:
+        #             args = args + queryOptions
+
         # append query specific options
         if queryName:
-            queryOptions = cliOptions['queries'][queryName]['options']
-            if len(queryOptions) > 0:
-                args = args + queryOptions
+            queryOptions = cliOptions.get('queries', {}).get(queryName, {}).get('options')
+            if queryOptions:
+                if len(queryOptions) > 0:
+                    args = args + queryOptions
         else:
             # append generic options (only if not custom query)
             options = cliOptions.get('options', None)

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -196,8 +196,8 @@ You might need to restart the editor for settings to be refreshed."""
 
         cliOptions = self.getOptionsForSgdbCli()
         beforeCli = cliOptions.get('before')
-        beforeQuery = cliOptions.get('queries', {}).get(queryName, {}).get('before')
         afterCli = cliOptions.get('after')
+        beforeQuery = cliOptions.get('queries', {}).get(queryName, {}).get('before')
         afterQuery = cliOptions.get('queries', {}).get(queryName, {}).get('after')
 
         # sometimes we preprocess the raw queries from user, in that case we already have a list
@@ -216,7 +216,8 @@ You might need to restart the editor for settings to be refreshed."""
         if afterQuery is not None:
             builtQueries.extend(afterQuery)
 
-        print(builtQueries)
+        # remove empty list items
+        builtQueries = list(filter(None, builtQueries))
 
         return '\n'.join(builtQueries)
 
@@ -238,28 +239,16 @@ You might need to restart the editor for settings to be refreshed."""
                     args = args + shlex.split(formattedItem)
 
         # append generic options
-        # options = cliOptions.get('options', None)
-        # if options:
-        #     args = args + options
+        options = cliOptions.get('options', None)
+        if options:
+            args = args + options
 
         # append query specific options (if present)
-        # if queryName:
-        #     queryOptions = cliOptions.get('queries', {}).get(queryName, {}).get.('options')
-        #     if queryOptions:
-        #         if len(queryOptions) > 0:
-        #             args = args + queryOptions
-
-        # append query specific options
         if queryName:
             queryOptions = cliOptions.get('queries', {}).get(queryName, {}).get('options')
             if queryOptions:
                 if len(queryOptions) > 0:
                     args = args + queryOptions
-        else:
-            # append generic options (only if not custom query)
-            options = cliOptions.get('options', None)
-            if options:
-                args = args + options
 
         # append main args - could be a single value or a list
         mainArgs = cliOptions['args']

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -248,7 +248,6 @@ You might need to restart the editor for settings to be refreshed."""
         # remove empty list items
         builtQueries = list(filter(None, builtQueries))
 
-        print('\n'.join(builtQueries))
         return '\n'.join(builtQueries)
 
     def buildArgs(self, queryName=None):

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -28,18 +28,20 @@
       "port"    :  5432,
       "database": "dbname",
       "username": "anotheruser",
-      // for PostgreSQL "password" is optional (setup "pgpass.conf" file instead)
+      // password is optional (setup "pgpass.conf" file instead)
       "password": "password",
       "encoding": "utf-8"
     },
     "Connection Oracle": {
       "type"    : "oracle",
       "host"    : "127.0.0.1",
-      "port"    :  1522,
+      "port"    :  1521,
       "database": "dbname",
       "username": "anotheruser",
       "password": "password",
       "service" : "servicename",
+      // nls_lang is optional
+      "nls_lang": "american_america.al32utf8",
       "encoding": "utf-8"
     },
     "Connection MSSQL": {
@@ -57,7 +59,8 @@
     },
     "Connection SQLite": {
       "type"    : "sqlite",
-      "database": "d:/sqlite/sample_db/chinook.db", // note the forward slashes in path
+      // note the forward slashes in path
+      "database": "d:/sqlite/sample_db/chinook.db",
       "encoding": "utf-8"
     }
   */


### PR DESCRIPTION
The highlight of this PR and the main structural and functional changes include: 

- changes how top level and per-query `options` apply to CLI invocations
- changes how `before` and `after` applied (top level and per-query)
- introduction of new `execute` named query section which is used when executing statements with `ST: Execute` and friends (Execute All File, Execute Query from History, etc)
- since above-mentioned items affect configuration for each RDBMS, review each of them, when possible fix, add new or missing functionality.

This one is a somewhat lengthy pull request, but as you can see it is for a good reason.

Here is a more detailed list of things that got fixed or improved in this PR:
- Ensure `before` and `after` runs on all commands.
Make sure that `before` and newly introduced `after` sql in `cli_options` settings is added to each command (if configured on the top level) as well as introduce optional per command `before` and "after` which are run in addition main `before` and `after`.
- Change how top level and per-query `options` work.
The new concept of applying `options` is: top-level `options` are applied to all CLI invocations (all queries). In addition to top-level `options` each named query `options` are appended.
- New named query `execute` is introduced, which helps to better control which options are applied when the user executes the query using `ST: Execute` or `ST: Execute All File`.
- Now all named query formatting is done via `str.format()`, therefore all instances of `%s` in template strings got replaced with "{0}", with back-patch support (i.e. `%s` should still work for those users who have it on their own user config, which overrides the default one)
- Use the `encoding` supplied in connection settings when writing to standard input and reading from standard output of CLI command
- General review of each RDBMS config to ensure it works with newly introduced changes
- Refactor `SQLToolsAPI/Connection.py`

These RDBMS got some improvements.
- [PostgreSQL] Added trailing semicolon - in case user would add something to `before` or `after` sql section the default config (multi-statement SQL) would work just fine
- [Oracle] Add support for functions & procedures completions as well as getting and functions & procedures source code (both top level and those in packages).
- [Oracle] Add support for quoted table and column names
- [Oracle] Add ability to configure `NSL_LANG` to match the server encoding
- [MySQL] Use `utf8` encoding by default when invoking MySQL CLI (which matches the encoding set in default connection config)
- [MSSQL] Add support for `ST : Explain Plan`

Fixes #120