### PR TITLE
Review settings, move important options to the top

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -96,12 +96,9 @@ def getConnections():
         connectionsObj[name] = createConnection(name, config, settings=settings.all())
 
     # project settings
-    try:
-        options = Window().project_data().get('connections', {})
-        for name, config in options.items():
-            connectionsObj[name] = createConnection(name, config, settings=settings.all())
-    except Exception:
-        pass
+    options = Window().project_data().get('connections', {})
+    for name, config in options.items():
+        connectionsObj[name] = createConnection(name, config, settings=settings.all())
 
     return connectionsObj
 

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -1,33 +1,7 @@
-// NOTE: it is strongly advised to override
-// only those settings that you wish to change
-// in your Users/SQLTools.sublime-settings
+// NOTE: it is strongly advised to override ONLY those settings
+// that you wish to change in your Users/SQLTools.sublime-settings.
+// Don't copy-paste the entire config.
 {
-    "debug"                 : true,
-    "thread_timeout"        : 15,     // query timeout in seconds
-    "history_size"          : 100,
-    "show_result_on_window" : false,
-    "clear_output"          : true,
-    "safe_limit"            : false,
-    "expand_to_paragraph"   : false,
-    "use_streams"           : false, // use streams for results
-    /**
-     * The list of syntax selectors for which the plugin autocompletion will be active.
-     * An empty list means autocompletion always active.
-     */
-    "selectors": ["source.sql", "source.pgsql", "source.plpgsql.postgres", "source.plsql.oracle", "source.tsql"],
-    /**
-     * Possible values for autocompletion: "basic", "smart", true ("smart"),
-     *                                      or false (disable)
-     * Completion keywords case is controlled by format.keyword_case (see below)
-     */
-    "autocompletion": "smart",
-    /**
-     * Possible values for show_query: "top", "bottom", true ("top"), or false (disable)
-     * When using regular output, this will determine where query details is displayed.
-     * In stream output mode, any option that isn't false will print query details at
-     * the bottom of result.
-     */
-    "show_query": false,
     /**
      * If DB cli binary is not in PATH, set the full path in "cli" section.
      * Note: forward slashes ("/") should be used in path. Example:
@@ -36,33 +10,61 @@
     "cli" : {
         "mysql"   : "mysql",
         "pgsql"   : "psql",
-        "oracle"  : "sqlplus",
         "mssql"   : "sqlcmd",
+        "oracle"  : "sqlplus",
+        "sqlite"  : "sqlite3",
         "vertica" : "vsql",
-        "sqsh"    : "sqsh",
         "firebird": "isql",
-        "sqlite"  : "sqlite3"
+        "sqsh"    : "sqsh"
     },
+    "expand_to_paragraph"   : false,  // use paragraph (text between newlines), if selection is empty
+    "show_result_on_window" : false,  // puts results either in output pannel or new window
+    "clear_output"          : true,   // clears the output of prev. query
+    "thread_timeout"        : 15,     // query timeout in seconds
+    "use_streams"           : false,  // stream the output line by line
+    "history_size"          : 100,    // number of queries to save in the history
     "show_records": {
         "limit": 50
     },
+    /**
+     * Print the queries that were executed to the output.
+     * Possible values for show_query: "top", "bottom", true ("top"), or false (disable)
+     * When using regular output, this will determine where query details is displayed.
+     * In stream output mode, any option that isn't false will print query details at
+     * the bottom of result.
+     */
+    "show_query": false,
+    /**
+     * Possible values for autocompletion: "basic", "smart", true ("smart"),
+     *                                      or false (disable)
+     * Completion keywords case is controlled by format.keyword_case (see below)
+     */
+    "autocompletion": "smart",
+    // Settings used for formatting the queries and autocompletions
     "format" : {
-        "keyword_case"    : "upper",
-        "identifier_case" : null,
-        "strip_comments"  : false,
-        "indent_tabs"     : false,
-        "indent_width"    : 4,
-        "reindent"        : true
+        "keyword_case"    : "upper",  // "upper", "lower", "capitalize" and null (leaves case intact)
+        "identifier_case" : null,     // "upper", "lower", "capitalize" and null (leaves case intact)
+        "strip_comments"  : false,    // formatting removes comments
+        "indent_tabs"     : false,    // use tabs instead of spaces
+        "indent_width"    : 4,        // indentation width
+        "reindent"        : true      // reindent code
     },
+    "debug": false,
+    "safe_limit": false,  // unless false, appends LIMIT clause to SELECT statements (not compatible with all DB's)
     "unescape_quotes" : [
         "php"
     ],
     /**
-     * Client options for you RDBMS.
-     * In this file, the section cli has the names you can use here. Eg: "pgsql": "psql"
-     * So here, you must have "psql with the same sections listed bellow (options, before, args and queries)"
+     * The list of syntax selectors for which the plugin autocompletion will be active.
+     * An empty list means autocompletion always active.
+     */
+    "selectors": ["source.sql", "source.pgsql", "source.plpgsql.postgres", "source.plsql.oracle", "source.tsql"],
+    /**
+     * Command line interface options for each RDBMS.
+     * In this file, the section `cli` above has the names you can use here. E.g.: "mysql", "pgsql", "oracle"
      *
-     * Avoid changing the brackets content in "args"
+     * Names in the curly brackets (e.g. `{host}`) in sections `args`, `args_optional`, `env`, `env_optional`
+     * are replaced by the values specified in the connetion.
      */
     "cli_options": {
         "pgsql": {
@@ -319,7 +321,7 @@
             "options": [],
             "before" : [],
             "after": [],
-            "args": "-h {host} -p {port} -U \"{username}\" -w \"{password}\" -d \"{database}\"",
+            "args": "-h \"{host}\" -p {port} -U \"{username}\" -w \"{password}\" -d \"{database}\"",
             "queries": {
                 "execute": {
                     "options": []
@@ -337,11 +339,11 @@
                     "options": []
                 },
                 "desc" : {
-                    "query": "select table_schema || '.' || table_name as tblname from v_catalog.tables where is_system_table = false;",
+                    "query": "select quote_ident(table_schema) || '.' || quote_ident(table_name) as obj from v_catalog.tables where is_system_table = false;",
                     "options": ["--tuples-only", "--no-vsqlrc"]
                 },
                 "columns": {
-                    "query": "select table_name || '.' || column_name as tblname from v_catalog.columns where is_system_table = false order by table_name, ordinal_position;",
+                    "query": "select quote_ident(table_name) || '.' || quote_ident(column_name) as obj from v_catalog.columns where is_system_table = false order by table_name, ordinal_position;",
                     "options": ["--tuples-only", "--no-vsqlrc"]
                 }
             }

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -4,7 +4,7 @@
     "Generic Template": {      // Connection name, used in menu (Display name)
       "type"     : "pgsql",    // DB type: (mysql, pgsql, oracle, vertica, sqlite, firebird, sqsh)
       "host"     : "HOSTNAME", // DB host to connect to
-      "port"     : "PORT",     // DB port
+      "port"     :  PORT,      // DB port
       "database" : "DATABASE", // DB name (for SQLite this is the path to DB file)
       "username" : "USERNAME", // DB username
       "password" : "PASSWORD", // DB password (see RDMBS specific comments below)
@@ -60,7 +60,26 @@
     "Connection SQLite": {
       "type"    : "sqlite",
       // note the forward slashes in path
-      "database": "d:/sqlite/sample_db/chinook.db",
+      "database": "c:/sqlite/sample_db/chinook.db",
+      "encoding": "utf-8"
+    },
+    "Connection Vertica": {
+      "type"    : "vertica",
+      "host"    : "localhost",
+      "port"    :  5433,
+      "username": "anotheruser",
+      "password": "password",
+      "database": "dbname",
+      "encoding": "utf-8"
+    },
+    "Connection Firebird": {
+      "type"    : "firebird",
+      "host"    : "localhost",
+      "port"    :  3050,
+      "username": "sysdba",
+      "password": "password",
+      // note the forward slashes (if path is used)
+      "database": "c:/firebird/examples/empbuild/employee.fdb",
       "encoding": "utf-8"
     }
   */


### PR DESCRIPTION
Quick summary:

* Review settings, move important options to the top
* Add more comments explaining the options in settings
* Add `Vertica` and `Firebird` to list of sample connections
* Adds support for `Vertica` quoted identifiers
* Removes unnecessary try...catch when loading project-specific connections