### PR TITLE
Fixes per-project connection settings

### DIFF
--- a/SQLTools.py
+++ b/SQLTools.py
@@ -96,9 +96,11 @@ def getConnections():
         connectionsObj[name] = createConnection(name, config, settings=settings.all())
 
     # project settings
-    options = Window().project_data().get('connections', {})
-    for name, config in options.items():
-        connectionsObj[name] = createConnection(name, config, settings=settings.all())
+    projectData = Window().project_data()
+    if projectData:
+        options = projectData.get('connections', {})
+        for name, config in options.items():
+            connectionsObj[name] = createConnection(name, config, settings=settings.all())
 
     return connectionsObj
 


### PR DESCRIPTION
Fixes per-project connection settings, as one would get the exception listed below if Sublime Text does not have an open project.
`AttributeError: 'NoneType' object has no attribute 'get'`