### PR TITLE
Add more options for expanding the empty selection, improve output

### DIFF
--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -18,13 +18,17 @@
         "sqsh"    : "sqsh"
     },
 
-    // use paragraph (text between newlines), if selection is empty
-    "expand_to_paragraph" : false,
+    // If there is no SQL selected, use "expanded" region.
+    // Possible options:
+    //  "file"      - entire file contents
+    //  "paragraph" - text between newlines relative to cursor(s)
+    //  "line"      - current line of cursor(s)
+    "expand_to": "file",
 
     // puts results either in output panel or new window
     "show_result_on_window" : false,
 
-    // clears the output of prev. query
+    // clears the output of previous query
     "clear_output" : true,
 
     // query timeout in seconds

--- a/SQLToolsAPI/Connection.py
+++ b/SQLToolsAPI/Connection.py
@@ -197,7 +197,7 @@ You might need to restart the editor for settings to be refreshed."""
         args = self.buildArgs(queryName)
         env = self.buildEnv()
 
-        Log("Query: " + queryToRun)
+        Log("Query: " + str(queryToRun))
 
         self.Command.createAndRun(args=args,
                                   env=env,


### PR DESCRIPTION
**Add more options for expanding the empty selection.**
Instead of config option `expand_to_paragraph`, introduce new option called `expand_to`, which can be configured to expand empty selection to:

- `line` - current line(s)
- `paragraph` - current paragraph(s)
- `file` - current file (view)

Also, keep the compatibility with old setting `expand_to_paragraph`, if set to `true`, then `expand_to` is considered to be set to `paragraph`.

**Improve the way the output is shown - the output panel is not shown until the first output from DB CLI arrives.**
Do not display the output panel right away - wait for query results to arrive and then display it.
This improves how SQLTools behaves for long running queries, so the user does not have to stare at the empty panel, waiting for results to arrive. Instead, he can continue editing the queries with more screen
real estate available.

Also, fix some typos in comments ))