### PR TITLE
Review and improve PostgreSQL, MySQL, MSSQL configs

### DIFF
--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -7,7 +7,7 @@
      * Note: forward slashes ("/") should be used in path. Example:
      *  "mysql"   : "c:/Program Files/MySQL/MySQL Server 5.7/bin/mysql.exe"
      */
-    "cli" : {
+    "cli": {
         "mysql"   : "mysql",
         "pgsql"   : "psql",
         "mssql"   : "sqlcmd",
@@ -26,32 +26,32 @@
     "expand_to": "file",
 
     // puts results either in output panel or new window
-    "show_result_on_window" : false,
+    "show_result_on_window": false,
 
     // clears the output of previous query
-    "clear_output" : true,
+    "clear_output": true,
 
     // query timeout in seconds
-    "thread_timeout" : 15,
+    "thread_timeout": 15,
 
     // stream the output line by line
-    "use_streams" : false,
+    "use_streams": false,
 
     // number of queries to save in the history
-    "history_size" : 100,
+    "history_size": 100,
 
     // unless false, appends LIMIT clause to SELECT statements (not compatible with all DB's)
     "safe_limit": false,
 
-    "unescape_quotes" : [
-        "php"
+    "unescape_quotes": [
+        // "php"
     ],
 
     "show_records": {
         "limit": 50
     },
 
-    "debug" : false,
+    "debug": false,
 
     /**
      * Print the queries that were executed to the output.
@@ -77,7 +77,7 @@
     // "indent_tabs"    , use tabs instead of spaces
     // "indent_width"   , indentation width
     // "reindent"       , reindent code
-    "format" : {
+    "format": {
         "keyword_case"    : "upper",
         "identifier_case" : null,
         "strip_comments"  : false,
@@ -111,7 +111,12 @@
             "options": ["--no-password"],
             "before": [],
             "after": [],
-            "args": "-h {host} -p {port} -U {username} -d {database}",
+            "args": "-d {database}",
+            "args_optional": [
+                "-h {host}",
+                "-p {port}",
+                "-U {username}"
+            ],
             "env_optional": {
                 "PGPASSWORD": "{password}"
             },
@@ -151,21 +156,31 @@
         },
 
         "mysql": {
-            "options": ["--default-character-set=utf8"],
+            "options": ["--no-auto-rehash", "--compress"],
             "before": [],
             "after": [],
-            "args": "-h{host} -P{port} -u\"{username}\" -D\"{database}\"",
-            "args_optional": ["--login-path=\"{login-path}\"", "--defaults-extra-file=\"{defaults-extra-file}\"", "-p\"{password}\""],
+            "args": "-D\"{database}\"",
+            "args_optional": [
+                "--login-path=\"{login-path}\"",
+                "--defaults-extra-file=\"{defaults-extra-file}\"",
+                "--default-character-set=\"{default-character-set}\"",
+                "-h\"{host}\"",
+                "-P{port}",
+                "-u\"{username}\""
+            ],
+            "env_optional": {
+                "MYSQL_PWD": "{password}"
+            },
             "queries": {
                 "execute": {
-                    "options": ["--table", "-f"]
+                    "options": ["--table"]
                 },
                 "show records": {
                     "query": "select * from {0} limit {1};",
                     "options": ["--table"]
                 },
                 "desc table": {
-                    "query": "desc {0}",
+                    "query": "desc {0};",
                     "options": ["--table"]
                 },
                 "desc function": {
@@ -178,15 +193,15 @@
                 },
                 "desc" : {
                     "query": "select concat(case when table_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_schema,'`') else table_schema end, '.', case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end) as obj from information_schema.tables where table_schema = database() order by table_name;",
-                    "options": ["--silent", "--raw"]
+                    "options": ["--silent", "--raw", "--skip-column-names"]
                 },
                 "columns": {
                     "query": "select concat(case when table_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',table_name,'`') else table_name end, '.', case when column_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',column_name,'`') else column_name end) as obj from information_schema.columns where table_schema = database() order by table_name, ordinal_position;",
-                    "options": ["--silent", "--raw"]
+                    "options": ["--silent", "--raw", "--skip-column-names"]
                 },
                 "functions": {
                     "query": "select concat(case when routine_schema REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_schema,'`') else routine_schema end, '.', case when routine_name REGEXP '[^0-9a-zA-Z$_]' then concat('`',routine_name,'`') else routine_name end, '()') as obj from information_schema.routines where routine_schema = database();",
-                    "options": ["--silent", "--raw"]
+                    "options": ["--silent", "--raw", "--skip-column-names"]
                 }
             }
         },
@@ -224,15 +239,15 @@
                 },
                 "desc": {
                     "query": "set nocount on; select concat(table_schema, '.', table_name) as obj from information_schema.tables order by table_schema, table_name;",
-                    "options": ["-h-1"]
+                    "options": ["-h-1", "-r1"]
                 },
                 "columns": {
                     "query": "set nocount on; select distinct concat(table_name, '.', column_name) as obj from information_schema.columns;",
-                    "options": ["-h-1"]
+                    "options": ["-h-1", "-r1"]
                 },
                 "functions": {
                     "query": "set nocount on; select concat(routine_schema, '.', routine_name) as obj from information_schema.routines order by routine_schema, routine_name;",
-                    "options": ["-h-1"]
+                    "options": ["-h-1", "-r1"]
                 }
             }
         },

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -40,16 +40,12 @@
     // number of queries to save in the history
     "history_size": 100,
 
-    // unless false, appends LIMIT clause to SELECT statements (not compatible with all DB's)
-    "safe_limit": false,
-
-    "unescape_quotes": [
-        // "php"
-    ],
-
     "show_records": {
         "limit": 50
     },
+
+    // unless false, appends LIMIT clause to SELECT statements (not compatible with all DB's)
+    "safe_limit": false,
 
     "debug": false,
 

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -20,6 +20,7 @@
       "password": "password",  // you will get a security warning in the output
       // "defaults-extra-file": "/path/to/defaults_file_with_password",  // use [client] or [mysql] section
       // "login-path": "your_login_path",  // login path in your ".mylogin.cnf"
+      "default-character-set": "utf8",
       "encoding": "utf-8"
     },
     "Connection PostgreSQL": {


### PR DESCRIPTION
**Review and improve PostgreSQL, MySQL, MSSQL configs**

PostgreSQL
* `host`, `port`, `username` are now optional (can be set via environment vars and other means). See PostgreSQL docs.

MySQL
* add configurable MySQL connection charset via `--default-character-set`
* add `--no-auto-rehash` and `--compress` to improve MySQL startup time and improve latency on slow networks
* `host`, `port`, `username` are now optional (can be set via `--defaults-extra-file` and `--login-path`)
* supply password via env var `MYSQL_PWD` to avoid security warning
* other minor tweaks

MSSQL
* for internal commands send (and ignore) errors to stderr


**Remove unused settings option `unescape_quotes`**

Encoding-related issues #162 #164