### PR TITLE
Release v0.9.9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.8
+current_version = 0.9.9
 files = SQLTools.py
 tag = True
 commit = True

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -1,4 +1,4 @@
-__version__ = "v0.9.8"
+__version__ = "v0.9.9"
 
 import sys
 import os

--- a/messages.json
+++ b/messages.json
@@ -13,5 +13,6 @@
     "0.9.5": "messages/v0.9.5.md",
     "0.9.6": "messages/v0.9.6.md",
     "0.9.7": "messages/v0.9.7.md",
-    "0.9.8": "messages/v0.9.8.md"
+    "0.9.8": "messages/v0.9.8.md",
+    "0.9.9": "messages/v0.9.9.md"
 }

--- a/messages/v0.9.9.md
+++ b/messages/v0.9.9.md
@@ -1,0 +1,10 @@
+## v0.9.9 Notes
+
+### Improvements
+
+* Use `utf-8` encoding if Connection `encoding` is not a valid python encoding
+
+
+### Fixes
+
+* Exception when Connection `encoding` is set to null [#177]


### PR DESCRIPTION
### Improvements
* Use `utf-8` encoding if Connection `encoding` is not a valid python encoding

### Fixes
* Exception when Connection `encoding` is set to null [#177]
