### PR TITLE
Add new command to Format All File

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -10,6 +10,7 @@
     { "keys": ["ctrl+e", "ctrl+b"], "command": "st_format" },
     { "keys": ["ctrl+e", "ctrl+q"], "command": "st_save_query" },
     { "keys": ["ctrl+e", "ctrl+r"], "command": "st_remove_saved_query" },
-    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries"},
-    { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}}
+    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries", "args": {"mode" : "run"}},
+    { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}},
+    { "keys": ["ctrl+e", "ctrl+i"], "command": "st_list_queries", "args": {"mode" : "insert"}}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -10,6 +10,7 @@
     { "keys": ["ctrl+e", "ctrl+b"], "command": "st_format" },
     { "keys": ["ctrl+e", "ctrl+q"], "command": "st_save_query" },
     { "keys": ["ctrl+e", "ctrl+r"], "command": "st_remove_saved_query" },
-    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries"},
-    { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}}
+    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries", "args": {"mode" : "run"}},
+    { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}},
+    { "keys": ["ctrl+e", "ctrl+i"], "command": "st_list_queries", "args": {"mode" : "insert"}}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -10,7 +10,7 @@
     { "keys": ["ctrl+e", "ctrl+b"], "command": "st_format" },
     { "keys": ["ctrl+e", "ctrl+q"], "command": "st_save_query" },
     { "keys": ["ctrl+e", "ctrl+r"], "command": "st_remove_saved_query" },
-    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries"},
+    { "keys": ["ctrl+e", "ctrl+l"], "command": "st_list_queries", "args": {"mode" : "run"}},
     { "keys": ["ctrl+e", "ctrl+o"], "command": "st_list_queries", "args": {"mode" : "open"}},
     { "keys": ["ctrl+e", "ctrl+i"], "command": "st_list_queries", "args": {"mode" : "insert"}}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -20,10 +20,6 @@
     "command": "st_history"
   },
   {
-    "caption": "ST: Type Query",
-    "command": "st_query"
-  },
-  {
     "caption": "ST: Show Table Records",
     "command": "st_show_records"
   },
@@ -59,8 +55,12 @@
     "args"   :  {"mode": "insert"}
   },
   {
-    "caption": "ST: Format Current SQL File",
+    "caption": "ST: Format SQL",
     "command": "st_format"
+  },
+  {
+    "caption": "ST: Format SQL All File",
+    "command": "st_format_all"
   },
   {
     "caption": "ST: About",

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -588,6 +588,14 @@ class StFormat(TextCommand):
             View().replace(edit, region, Utils.formatSql(textToFormat, settings.get('format', {})))
 
 
+class StFormatAll(TextCommand):
+    @staticmethod
+    def run(edit):
+        region = sublime.Region(0, View().size())
+        textToFormat = View().substr(region)
+        View().replace(edit, region, Utils.formatSql(textToFormat, settings.get('format', {})))
+
+
 class StVersion(WindowCommand):
     @staticmethod
     def run():


### PR DESCRIPTION
Adding new SQLTools command `st_format_all` which can be used to format the whole file.

Also fixes inconsistencies between Windows, Linux and Mac keybindings - Linux and Mac didn't have a keybinding for one of the commands.

Fixes #182