### PR TITLE
Add command to reset table, columns and functions cache

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -32,6 +32,10 @@
     "command": "st_desc_function"
   },
   {
+    "caption": "ST: Remove Table and Functions cache",
+    "command": "st_clear_cache"
+  },
+  {
     "caption": "ST: Save Query",
     "command": "st_save_query"
   },

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -345,14 +345,18 @@ class ST(EventListener):
         connListNames = list(ST.connectionList.keys())
         connListNames.sort()
         ST.conn = ST.connectionList.get(connListNames[index])
+        ST.reset_cache(tablesCallback, columnsCallback, functionsCallback)
+
+        Log('Connection {0} selected'.format(ST.conn))
+
+    @staticmethod
+    def reset_cache(tablesCallback=None, columnsCallback=None, functionsCallback=None):
         # clear list of identifiers in case connection is changed
         ST.tables = []
         ST.columns = []
         ST.functions = []
 
         ST.loadConnectionData(tablesCallback, columnsCallback, functionsCallback)
-
-        Log('Connection {0} selected'.format(ST.conn))
 
     @staticmethod
     def selectConnection(tablesCallback=None, columnsCallback=None, functionsCallback=None):
@@ -540,6 +544,12 @@ class StDescFunction(WindowCommand):
         # from "function_name(int)"
         ST.selectFunction(cb)
 
+class StClearCache(WindowCommand):
+    @staticmethod
+    def run():
+        if not ST.conn:
+            return
+        ST.reset_cache()
 
 class StExplainPlan(WindowCommand):
     @staticmethod


### PR DESCRIPTION
When you change the database structure, i would like to update the data without having to restart sublime or to reselect the connection 